### PR TITLE
Poc module block/unblock perf improvement and event loop api

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -533,6 +533,7 @@ void moduleReleaseTempClient(client *c)
         discardTransaction(c);
         pubsubUnsubscribeAllChannels(c,0);
         pubsubUnsubscribeAllPatterns(c,0);
+        listEmpty(c->reply);
         resetClient(c); /* frees the contents of argv */
         zfree(c->argv);
         c->argv = NULL;

--- a/src/module.c
+++ b/src/module.c
@@ -533,6 +533,7 @@ void moduleReleaseTempClient(client *c)
         freeClient(c);
     } else {
         listEmpty(c->reply);
+        c->reply_bytes = 0;
         resetClient(c); /* frees the contents of argv */
         c->bufpos = 0;
         moduleTempClients[moduleTempClientCount++] = c;

--- a/src/module.c
+++ b/src/module.c
@@ -9578,6 +9578,7 @@ void moduleInitModulesSystemLast(void) {
 
 void moduleInitModulesSystem(void) {
     moduleUnblockedClients = listCreate();
+    moduleTempClients = listCreate();
     server.loadmodule_queue = listCreate();
     modules = dictCreate(&modulesDictType);
 

--- a/src/module.c
+++ b/src/module.c
@@ -10423,6 +10423,21 @@ int RM_GetDbIdFromDefragCtx(RedisModuleDefragCtx *ctx) {
     return ctx->dbid;
 }
 
+int RM_CreateFileEvent(int fd, int mask, RedisModuleFileEventCallback proc, void *clientData)
+{
+    int ret = aeCreateFileEvent(server.el, fd, mask, (aeFileProc*)proc, clientData);
+    if (ret != AE_OK) {
+        return REDISMODULE_ERR;
+    }
+
+    return REDISMODULE_OK;
+}
+
+void RM_DeleteFileEvent(int fd, int mask)
+{
+    aeDeleteFileEvent(server.el, fd, mask);
+}
+
 /* Register all the APIs we export. Keep this function at the end of the
  * file so that's easy to seek it to add new entries. */
 void moduleRegisterCoreAPI(void) {
@@ -10496,6 +10511,8 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(CallReplyLength);
     REGISTER_API(CallReplyArrayElement);
     REGISTER_API(CallReplyStringPtr);
+    REGISTER_API(CreateFileEvent);
+    REGISTER_API(DeleteFileEvent);
     REGISTER_API(CreateStringFromCallReply);
     REGISTER_API(CreateString);
     REGISTER_API(CreateStringFromLongLong);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -866,7 +866,7 @@ REDISMODULE_API int (*RedisModule_SetCommandKeySpecBeginSearchIndex)(RedisModule
 REDISMODULE_API int (*RedisModule_SetCommandKeySpecBeginSearchKeyword)(RedisModuleCtx *ctx, const char *name, int spec_id, const char *keyword, int startfrom) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_SetCommandKeySpecFindKeysRange)(RedisModuleCtx *ctx, const char *name, int spec_id, int lastkey, int keystep, int limit) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_SetCommandKeySpecFindKeysKeynum)(RedisModuleCtx *ctx, const char *name, int spec_id, int keynumidx, int firstkey, int keystep) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_CreateFileEvent)(int fd, int mask, RedisModuleFileCallback proc, void *clientData) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_CreateFileEvent)(int fd, int mask, RedisModuleFileEventCallback proc, void *clientData) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_DeleteFileEvent)(int fd, int mask) REDISMODULE_ATTR;
 
 /* Experimental APIs */

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -240,6 +240,12 @@ typedef uint64_t RedisModuleTimerID;
  * are modified from the user's sperspective, to invalidate WATCH. */
 #define REDISMODULE_OPTION_NO_IMPLICIT_SIGNAL_MODIFIED (1<<1)
 
+#define REDISMODULE_FILE_EVENT_NONE 0
+#define REDISMODULE_FILE_EVENT_READABLE 1
+#define REDISMODULE_FILE_EVENT_WRITABLE 2
+
+typedef void (*RedisModuleFileEventCallback)(void* unused, int fd, void *clientData, int mask);
+
 /* Server events definitions.
  * Those flags should not be used directly by the module, instead
  * the module should use RedisModuleEvent_* variables */
@@ -860,6 +866,8 @@ REDISMODULE_API int (*RedisModule_SetCommandKeySpecBeginSearchIndex)(RedisModule
 REDISMODULE_API int (*RedisModule_SetCommandKeySpecBeginSearchKeyword)(RedisModuleCtx *ctx, const char *name, int spec_id, const char *keyword, int startfrom) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_SetCommandKeySpecFindKeysRange)(RedisModuleCtx *ctx, const char *name, int spec_id, int lastkey, int keystep, int limit) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_SetCommandKeySpecFindKeysKeynum)(RedisModuleCtx *ctx, const char *name, int spec_id, int keynumidx, int firstkey, int keystep) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_CreateFileEvent)(int fd, int mask, RedisModuleFileCallback proc, void *clientData) REDISMODULE_ATTR;
+REDISMODULE_API void (*RedisModule_DeleteFileEvent)(int fd, int mask) REDISMODULE_ATTR;
 
 /* Experimental APIs */
 #ifdef REDISMODULE_EXPERIMENTAL_API
@@ -1013,6 +1021,8 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(CallReplyLength);
     REDISMODULE_GET_API(CallReplyArrayElement);
     REDISMODULE_GET_API(CallReplyStringPtr);
+    REDISMODULE_GET_API(CreateFileEvent);
+    REDISMODULE_GET_API(DeleteFileEvent);
     REDISMODULE_GET_API(CreateStringFromCallReply);
     REDISMODULE_GET_API(CreateString);
     REDISMODULE_GET_API(CreateStringFromLongLong);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -258,7 +258,8 @@ typedef uint64_t RedisModuleTimerID;
 #define REDISMODULE_EVENT_REPL_BACKUP 12 /* Deprecated since Redis 7.0, not used anymore. */
 #define REDISMODULE_EVENT_FORK_CHILD 13
 #define REDISMODULE_EVENT_REPL_ASYNC_LOAD 14
-#define _REDISMODULE_EVENT_NEXT 15 /* Next event flag, should be updated if a new event added. */
+#define REDISMODULE_EVENT_BEFORE_SLEEP 15
+#define _REDISMODULE_EVENT_NEXT 16 /* Next event flag, should be updated if a new event added. */
 
 typedef struct RedisModuleEvent {
     uint64_t id;        /* REDISMODULE_EVENT_... defines. */
@@ -331,7 +332,11 @@ static const RedisModuleEvent
     RedisModuleEvent_ForkChild = {
         REDISMODULE_EVENT_FORK_CHILD,
         1
-    };
+    },
+    RedisModuleEvent_BeforeSleep = {
+        REDISMODULE_EVENT_BEFORE_SLEEP,
+        1
+};
 
 /* Those are values that are used for the 'subevent' callback argument. */
 #define REDISMODULE_SUBEVENT_PERSISTENCE_RDB_START 0

--- a/src/server.c
+++ b/src/server.c
@@ -3441,6 +3441,7 @@ void beforeSleep(struct aeEventLoop *eventLoop) {
      * blocking commands. */
     if (moduleCount()) {
         moduleFireServerEvent(REDISMODULE_EVENT_BEFORE_SLEEP, 0, NULL);
+        atomicSetWithSync(server.module_blocked_clients_processed, 1);
         moduleHandleBlockedClients();
     }
 
@@ -3523,6 +3524,8 @@ void afterSleep(struct aeEventLoop *eventLoop) {
     /* Acquire the modules GIL so that their threads won't touch anything. */
     if (!ProcessingEventsWhileBlocked) {
         if (moduleCount()) {
+            atomicSetWithSync(server.module_blocked_clients_processed, 0);
+
             mstime_t latency;
             latencyStartMonitor(latency);
 

--- a/src/server.c
+++ b/src/server.c
@@ -3439,7 +3439,10 @@ void beforeSleep(struct aeEventLoop *eventLoop) {
 
     /* Check if there are clients unblocked by modules that implement
      * blocking commands. */
-    if (moduleCount()) moduleHandleBlockedClients();
+    if (moduleCount()) {
+        moduleFireServerEvent(REDISMODULE_EVENT_BEFORE_SLEEP, 0, NULL);
+        moduleHandleBlockedClients();
+    }
 
     /* Try to process pending commands for clients that were just unblocked. */
     if (listLength(server.unblocked_clients))

--- a/src/server.h
+++ b/src/server.h
@@ -1363,6 +1363,7 @@ struct redisServer {
     int module_blocked_pipe[2]; /* Pipe used to awake the event loop if a
                                    client blocked on a module command needs
                                    to be processed. */
+    redisAtomic int module_blocked_clients_processed;
     pid_t child_pid;            /* PID of current child */
     int child_type;             /* Type of current child */
     client *module_client;      /* "Fake" client to call Redis from modules */


### PR DESCRIPTION
- Cache temp clients
- Write to wakeup pipe once, only if redis main already called moduleHandleBlockedClients(). Otherwise, it means redis main thread will  call moduleHandleBlockedClients() later, no need to write to pipe. It's already awake. 
- Added two functions to module api, CreateFileEvent / DeleteFileEvent, to register fd's to the redis main event loop.