### PR TITLE
Add RM_RdbLoad() and RM_RdbSave()

### DIFF
--- a/runtest-moduleapi
+++ b/runtest-moduleapi
@@ -52,4 +52,5 @@ $TCLSH tests/test_helper.tcl \
 --single unit/moduleapi/publish \
 --single unit/moduleapi/usercall \
 --single unit/moduleapi/postnotifications \
+--single unit/moduleapi/rdbloadsave \
 "${@}"

--- a/src/module.c
+++ b/src/module.c
@@ -12210,46 +12210,93 @@ int RM_LoadConfigs(RedisModuleCtx *ctx) {
     return REDISMODULE_OK;
 }
 
-/* Load the RDB file pointed by `filename`. Dataset will be cleared first and
- * then the RDB file will be loaded.
+/* --------------------------------------------------------------------------
+ * ## RDB load/save API
+ * -------------------------------------------------------------------------- */
+
+#define REDISMODULE_RDB_STREAM_FILE 1
+
+typedef struct RedisModuleRdbStream {
+    int type;
+
+    union {
+        char *filename;
+    } data;
+} RedisModuleRdbStream;
+
+/* Create a stream object to save/load RDB to/from a file.
+ *
+ * This function returns a pointer to RedisModuleRdbStream which is owned
+ * by the caller. It requires a call to RM_RdbStreamFree() to free
+ * the object.
+ * */
+RedisModuleRdbStream *RM_RdbStreamCreateFromFile(const char *filename) {
+    RedisModuleRdbStream *stream = zmalloc(sizeof(*stream));
+    stream->type = REDISMODULE_RDB_STREAM_FILE;
+    stream->data.filename = zstrdup(filename);
+    return stream;
+}
+
+/* Release an RDB stream object. */
+void RM_RdbStreamFree(RedisModuleRdbStream *stream) {
+    switch (stream->type) {
+        case REDISMODULE_RDB_STREAM_FILE:
+            zfree(stream->data.filename);
+            break;
+        default:
+            serverAssert(0);
+            break;
+    }
+    zfree(stream);
+}
+
+/* Load the RDB file from the `stream`. Dataset will be cleared first and then
+ * the RDB file will be loaded.
  *
  * `flags` must be zero. This parameter is for future use.
  *
  * On success REDISMODULE_OK is returned, otherwise
  * REDISMODULE_ERR is returned and errno is set to the following values:
  *
- * * EINVAL: `filename` is NULL or `flags` value is invalid.
- * * ENOENT: File does not exist.
+ * * EINVAL: `stream` is NULL or `flags` value is invalid.
  * * EIO: Failed to load the RDB file. Check server logs for more info.
+ *
+ * Example:
+ *
+ *     RedisModuleRdbStream *s = RedisModule_RdbStreamCreateFromFile("exp.rdb");
+ *     RedisModule_RdbLoad(s, 0);
+ *     RedisModule_RdbStreamFree(s);
  */
-int RM_RdbLoad(const char *filename, int flags) {
+int RM_RdbLoad(RedisModuleRdbStream *stream, int flags) {
     errno = 0;
 
-    if (!filename || flags != 0) {
+    if (!stream || flags != 0) {
         errno = EINVAL;
         return REDISMODULE_ERR;
     }
 
     if (server.aof_state != AOF_OFF) stopAppendOnly();
 
-    /* Kill existing RDB fork as it is saving outdated data. */
+    /* Kill existing RDB fork as it is saving outdated data. Also killing it
+     * will prevent COW memory issue. */
     if (server.child_type == CHILD_TYPE_RDB) killRDBChild();
 
     emptyData(-1,EMPTYDB_NO_FLAGS,NULL);
 
     /* rdbLoad() can go back to the networking and process network events. If
-     * this function is called inside a command callback, we don't want to
+     * RM_RdbLoad() is called inside a command callback, we don't want to
      * process the current client. Otherwise, we may free the client or try to
      * process next message while we are already in the command callback. */
     if (server.current_client) protectClient(server.current_client);
 
-    int ret = rdbLoad((char*)filename,NULL,RDBFLAGS_NONE);
+    serverAssert(stream->type == REDISMODULE_RDB_STREAM_FILE);
+    int ret = rdbLoad(stream->data.filename,NULL,RDBFLAGS_NONE);
 
     if (server.current_client) unprotectClient(server.current_client);
     if (server.aof_state != AOF_OFF) startAppendOnly();
 
     if (ret != RDB_OK) {
-        errno = (ret == RDB_NOT_EXIST) ? ENOENT : EIO;
+        errno = EIO;
         return REDISMODULE_ERR;
     }
 
@@ -12257,35 +12304,40 @@ int RM_RdbLoad(const char *filename, int flags) {
     return REDISMODULE_OK;
 }
 
-/* Save dataset into the RDB file pointed by `filename`.
+/* Save dataset to the RDB stream.
  *
  * `flags` must be zero. This parameter is for future use.
+ *
+ * If there is already a fork saving to the RDB file e.g. bgsave is in progress,
+ * then, module should guarantee that `stream` does not point to the same file.
+ * Otherwise, this function and RDB fork will try to write to the same file.
  *
  * On success REDISMODULE_OK is returned, otherwise
  * REDISMODULE_ERR is returned and errno is set to the following values:
  *
- * * EINVAL: `filename` is NULL or `flags` value is invalid.
- * * EINPROGRESS: There is already an RDB fork saving into the same file.
+ * * EINVAL: `stream` is NULL or `flags` value is invalid.
  * * EIO: Failed to load the RDB file. Check server logs for more info.
+ *
+ * Example:
+ *
+ *     RedisModuleRdbStream *s = RedisModule_RdbStreamCreateFromFile("exp.rdb");
+ *     RedisModule_RdbSave(s, 0);
+ *     RedisModule_RdbStreamFree(s);
  */
-int RM_RdbSave(const char *filename, int flags) {
+int RM_RdbSave(RedisModuleRdbStream *stream, int flags) {
     errno = 0;
 
-    if (!filename || flags != 0) {
+    if (!stream || flags != 0) {
         errno = EINVAL;
         return REDISMODULE_ERR;
     }
 
-    if (strcmp(filename,server.rdb_filename) == 0 &&
-        server.child_type == CHILD_TYPE_RDB) {
-        errno = EINPROGRESS;
-        return REDISMODULE_ERR;
-    }
+    serverAssert(stream->type == REDISMODULE_RDB_STREAM_FILE);
 
     rdbSaveInfo rsi, *rsiptr;
     rsiptr = rdbPopulateSaveInfo(&rsi);
 
-    if (rdbSave(SLAVE_REQ_NONE,(char*)filename,rsiptr) != C_OK) {
+    if (rdbSave(SLAVE_REQ_NONE,stream->data.filename,rsiptr) != C_OK) {
         errno = EIO;
         return REDISMODULE_ERR;
     }
@@ -13193,6 +13245,8 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(RegisterStringConfig);
     REGISTER_API(RegisterEnumConfig);
     REGISTER_API(LoadConfigs);
+    REGISTER_API(RdbStreamCreateFromFile);
+    REGISTER_API(RdbStreamFree);
     REGISTER_API(RdbLoad);
     REGISTER_API(RdbSave);
 }

--- a/src/module.c
+++ b/src/module.c
@@ -12333,10 +12333,7 @@ int RM_RdbSave(RedisModuleRdbStream *stream, int flags) {
 
     serverAssert(stream->type == REDISMODULE_RDB_STREAM_FILE);
 
-    rdbSaveInfo rsi, *rsiptr;
-    rsiptr = rdbPopulateSaveInfo(&rsi);
-
-    if (rdbSave(SLAVE_REQ_NONE,stream->data.filename,rsiptr) != C_OK) {
+    if (rdbSaveToFile(stream->data.filename) != C_OK) {
         errno = EIO;
         return REDISMODULE_ERR;
     }

--- a/src/module.c
+++ b/src/module.c
@@ -12210,7 +12210,8 @@ int RM_LoadConfigs(RedisModuleCtx *ctx) {
     return REDISMODULE_OK;
 }
 
-/* Load the RDB file pointed by `filename`.
+/* Load the RDB file pointed by `filename`. Dataset will be cleared first and
+ * then the RDB file will be loaded.
  *
  * `flags` must be zero. This parameter is for future use.
  *

--- a/src/module.c
+++ b/src/module.c
@@ -12228,8 +12228,7 @@ typedef struct RedisModuleRdbStream {
  *
  * This function returns a pointer to RedisModuleRdbStream which is owned
  * by the caller. It requires a call to RM_RdbStreamFree() to free
- * the object.
- * */
+ * the object. */
 RedisModuleRdbStream *RM_RdbStreamCreateFromFile(const char *filename) {
     RedisModuleRdbStream *stream = zmalloc(sizeof(*stream));
     stream->type = REDISMODULE_RDB_STREAM_FILE;
@@ -12240,12 +12239,12 @@ RedisModuleRdbStream *RM_RdbStreamCreateFromFile(const char *filename) {
 /* Release an RDB stream object. */
 void RM_RdbStreamFree(RedisModuleRdbStream *stream) {
     switch (stream->type) {
-        case REDISMODULE_RDB_STREAM_FILE:
-            zfree(stream->data.filename);
-            break;
-        default:
-            serverAssert(0);
-            break;
+    case REDISMODULE_RDB_STREAM_FILE:
+        zfree(stream->data.filename);
+        break;
+    default:
+        serverAssert(0);
+        break;
     }
     zfree(stream);
 }

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1440,7 +1440,7 @@ static int rdbSaveInternal(int req, const char *filename, rdbSaveInfo *rsi) {
     char cwd[MAXPATHLEN]; /* Current working dir path for error messages. */
     rio rdb;
     int error = 0;
-    char *err_op;
+    char *err_op;    /* For a detailed log */
 
     FILE *fp = fopen(filename,"w");
     if (!fp) {
@@ -1460,7 +1460,7 @@ static int rdbSaveInternal(int req, const char *filename, rdbSaveInfo *rsi) {
     if (server.rdb_save_incremental_fsync)
         rioSetAutoSync(&rdb,REDIS_AUTOSYNC_BYTES);
 
-    if (rdbSaveRio(req,&rdb,&error,RDBFLAGS_NONE,rsi) != C_OK) {
+    if (rdbSaveRio(req,&rdb,&error,RDBFLAGS_NONE,rsi) == C_ERR) {
         errno = error;
         err_op = "rdbSaveRio";
         goto werr;

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1436,78 +1436,31 @@ werr: /* Write error. */
     return C_ERR;
 }
 
-/* Save DB to the file. Similar to rdbSave() but this function won't use a
- * temporary file and won't update the metrics. */
-int rdbSaveToFile(const char *filename) {
+static int rdbSaveInternal(int req, const char *filename, rdbSaveInfo *rsi) {
+    char cwd[MAXPATHLEN]; /* Current working dir path for error messages. */
     rio rdb;
     int error = 0;
     char *err_op;
 
     FILE *fp = fopen(filename,"w");
     if (!fp) {
-        serverLog(LL_WARNING, "Failed to open the RDB file %s to save: %s",
-            filename, strerror(errno));
-        return C_ERR;
-    }
-
-    rioInitWithFile(&rdb,fp);
-    startSaving(RDBFLAGS_NONE);
-
-    if (server.rdb_save_incremental_fsync)
-        rioSetAutoSync(&rdb,REDIS_AUTOSYNC_BYTES);
-
-    if (rdbSaveRio(SLAVE_REQ_NONE,&rdb,&error,RDBFLAGS_NONE,NULL) != C_OK) {
-        errno = error;
-        err_op = "rdbSaveRio";
-        goto werr;
-    }
-
-    /* Make sure data will not remain on the OS's output buffers */
-    if (fflush(fp)) { err_op = "fflush"; goto werr; }
-    if (fsync(fileno(fp))) { err_op = "fsync"; goto werr; }
-    if (fclose(fp)) { fp = NULL; err_op = "fclose"; goto werr; }
-
-    stopSaving(1);
-    return C_OK;
-
-werr:
-    serverLog(LL_WARNING,"Write error while saving DB to the disk(%s): %s", err_op, strerror(errno));
-    if (fp) fclose(fp);
-    unlink(filename);
-    stopSaving(0);
-    return C_ERR;
-}
-
-/* Save the DB on disk. Return C_ERR on error, C_OK on success. */
-int rdbSave(int req, char *filename, rdbSaveInfo *rsi) {
-    char tmpfile[256];
-    char cwd[MAXPATHLEN]; /* Current working dir path for error messages. */
-    FILE *fp = NULL;
-    rio rdb;
-    int error = 0;
-    char *err_op;    /* For a detailed log */
-
-    snprintf(tmpfile,256,"temp-%d.rdb", (int) getpid());
-    fp = fopen(tmpfile,"w");
-    if (!fp) {
         char *str_err = strerror(errno);
         char *cwdp = getcwd(cwd,MAXPATHLEN);
         serverLog(LL_WARNING,
             "Failed opening the temp RDB file %s (in server root dir %s) "
             "for saving: %s",
-            tmpfile,
+            filename,
             cwdp ? cwdp : "unknown",
             str_err);
         return C_ERR;
     }
 
     rioInitWithFile(&rdb,fp);
-    startSaving(RDBFLAGS_NONE);
 
     if (server.rdb_save_incremental_fsync)
         rioSetAutoSync(&rdb,REDIS_AUTOSYNC_BYTES);
 
-    if (rdbSaveRio(req,&rdb,&error,RDBFLAGS_NONE,rsi) == C_ERR) {
+    if (rdbSaveRio(req,&rdb,&error,RDBFLAGS_NONE,rsi) != C_OK) {
         errno = error;
         err_op = "rdbSaveRio";
         goto werr;
@@ -1517,7 +1470,41 @@ int rdbSave(int req, char *filename, rdbSaveInfo *rsi) {
     if (fflush(fp)) { err_op = "fflush"; goto werr; }
     if (fsync(fileno(fp))) { err_op = "fsync"; goto werr; }
     if (fclose(fp)) { fp = NULL; err_op = "fclose"; goto werr; }
-    fp = NULL;
+
+    return C_OK;
+
+werr:
+    serverLog(LL_WARNING,"Write error while saving DB to the disk(%s): %s", err_op, strerror(errno));
+    if (fp) fclose(fp);
+    unlink(filename);
+    return C_ERR;
+}
+
+/* Save DB to the file. Similar to rdbSave() but this function won't use a
+ * temporary file and won't update the metrics. */
+int rdbSaveToFile(const char *filename) {
+    startSaving(RDBFLAGS_NONE);
+
+    if (rdbSaveInternal(SLAVE_REQ_NONE,filename,NULL) != C_OK) {
+        stopSaving(0);
+        return C_ERR;
+    }
+
+    stopSaving(1);
+    return C_OK;
+}
+
+/* Save the DB on disk. Return C_ERR on error, C_OK on success. */
+int rdbSave(int req, char *filename, rdbSaveInfo *rsi) {
+    char tmpfile[256];
+    char cwd[MAXPATHLEN]; /* Current working dir path for error messages. */
+    rio rdb;
+    int error = 0;
+
+    startSaving(RDBFLAGS_NONE);
+    snprintf(tmpfile,256,"temp-%d.rdb", (int) getpid());
+
+    if (rdbSaveInternal(req,tmpfile,rsi) != C_OK) goto werr;
     
     /* Use RENAME to make sure the DB file is changed atomically only
      * if the generate DB file is ok. */
@@ -1531,11 +1518,13 @@ int rdbSave(int req, char *filename, rdbSaveInfo *rsi) {
             filename,
             cwdp ? cwdp : "unknown",
             str_err);
-        unlink(tmpfile);
-        stopSaving(0);
-        return C_ERR;
+        goto werr;
     }
-    if (fsyncFileDir(filename) == -1) { err_op = "fsyncFileDir"; goto werr; }
+    if (fsyncFileDir(filename) != 0) {
+        serverLog(LL_WARNING,
+            "Failed to fsync directory while saving DB: %s", strerror(errno));
+        goto werr;
+    }
 
     serverLog(LL_NOTICE,"DB saved on disk");
     server.dirty = 0;
@@ -1545,8 +1534,6 @@ int rdbSave(int req, char *filename, rdbSaveInfo *rsi) {
     return C_OK;
 
 werr:
-    serverLog(LL_WARNING,"Write error saving DB on disk(%s): %s", err_op, strerror(errno));
-    if (fp) fclose(fp);
     unlink(tmpfile);
     stopSaving(0);
     return C_ERR;

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1498,8 +1498,6 @@ int rdbSaveToFile(const char *filename) {
 int rdbSave(int req, char *filename, rdbSaveInfo *rsi) {
     char tmpfile[256];
     char cwd[MAXPATHLEN]; /* Current working dir path for error messages. */
-    rio rdb;
-    int error = 0;
 
     startSaving(RDBFLAGS_NONE);
     snprintf(tmpfile,256,"temp-%d.rdb", (int) getpid());

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -156,6 +156,7 @@ int rdbLoad(char *filename, rdbSaveInfo *rsi, int rdbflags);
 int rdbSaveBackground(int req, char *filename, rdbSaveInfo *rsi);
 int rdbSaveToSlavesSockets(int req, rdbSaveInfo *rsi);
 void rdbRemoveTempFile(pid_t childpid, int from_signal);
+int rdbSaveToFile(const char *filename);
 int rdbSave(int req, char *filename, rdbSaveInfo *rsi);
 ssize_t rdbSaveObject(rio *rdb, robj *o, robj *key, int dbid);
 size_t rdbSavedObjectLen(robj *o, robj *key, int dbid);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -864,6 +864,7 @@ typedef struct RedisModuleServerInfoData RedisModuleServerInfoData;
 typedef struct RedisModuleScanCursor RedisModuleScanCursor;
 typedef struct RedisModuleUser RedisModuleUser;
 typedef struct RedisModuleKeyOptCtx RedisModuleKeyOptCtx;
+typedef struct RedisModuleRdbStream RedisModuleRdbStream;
 
 typedef int (*RedisModuleCmdFunc)(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 typedef void (*RedisModuleDisconnectFunc)(RedisModuleCtx *ctx, RedisModuleBlockedClient *bc);
@@ -1275,8 +1276,10 @@ REDISMODULE_API int (*RedisModule_RegisterNumericConfig)(RedisModuleCtx *ctx, co
 REDISMODULE_API int (*RedisModule_RegisterStringConfig)(RedisModuleCtx *ctx, const char *name, const char *default_val, unsigned int flags, RedisModuleConfigGetStringFunc getfn, RedisModuleConfigSetStringFunc setfn, RedisModuleConfigApplyFunc applyfn, void *privdata) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_RegisterEnumConfig)(RedisModuleCtx *ctx, const char *name, int default_val, unsigned int flags, const char **enum_values, const int *int_values, int num_enum_vals, RedisModuleConfigGetEnumFunc getfn, RedisModuleConfigSetEnumFunc setfn, RedisModuleConfigApplyFunc applyfn, void *privdata) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_LoadConfigs)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_RdbLoad)(const char *filename, int flags) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_RdbSave)(const char *filename, int flags) REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleRdbStream *(*RedisModule_RdbStreamCreateFromFile)(const char *filename) REDISMODULE_ATTR;
+REDISMODULE_API void (*RedisModule_RdbStreamFree)(RedisModuleRdbStream *stream) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_RdbLoad)(RedisModuleRdbStream *stream, int flags) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_RdbSave)(RedisModuleRdbStream *stream, int flags) REDISMODULE_ATTR;
 
 #define RedisModule_IsAOFClient(id) ((id) == UINT64_MAX)
 
@@ -1623,6 +1626,8 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(RegisterStringConfig);
     REDISMODULE_GET_API(RegisterEnumConfig);
     REDISMODULE_GET_API(LoadConfigs);
+    REDISMODULE_GET_API(RdbStreamCreateFromFile);
+    REDISMODULE_GET_API(RdbStreamFree);
     REDISMODULE_GET_API(RdbLoad);
     REDISMODULE_GET_API(RdbSave);
 

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -1275,6 +1275,8 @@ REDISMODULE_API int (*RedisModule_RegisterNumericConfig)(RedisModuleCtx *ctx, co
 REDISMODULE_API int (*RedisModule_RegisterStringConfig)(RedisModuleCtx *ctx, const char *name, const char *default_val, unsigned int flags, RedisModuleConfigGetStringFunc getfn, RedisModuleConfigSetStringFunc setfn, RedisModuleConfigApplyFunc applyfn, void *privdata) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_RegisterEnumConfig)(RedisModuleCtx *ctx, const char *name, int default_val, unsigned int flags, const char **enum_values, const int *int_values, int num_enum_vals, RedisModuleConfigGetEnumFunc getfn, RedisModuleConfigSetEnumFunc setfn, RedisModuleConfigApplyFunc applyfn, void *privdata) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_LoadConfigs)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_RdbLoad)(const char *filename, int flags) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_RdbSave)(const char *filename, int flags) REDISMODULE_ATTR;
 
 #define RedisModule_IsAOFClient(id) ((id) == UINT64_MAX)
 
@@ -1621,6 +1623,8 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(RegisterStringConfig);
     REDISMODULE_GET_API(RegisterEnumConfig);
     REDISMODULE_GET_API(LoadConfigs);
+    REDISMODULE_GET_API(RdbLoad);
+    REDISMODULE_GET_API(RdbSave);
 
     if (RedisModule_IsModuleNameBusy && RedisModule_IsModuleNameBusy(name)) return REDISMODULE_ERR;
     RedisModule_SetModuleAttribs(ctx,name,ver,apiver);

--- a/tests/modules/Makefile
+++ b/tests/modules/Makefile
@@ -60,7 +60,8 @@ TEST_MODULES = \
     moduleconfigstwo.so \
     publish.so \
     usercall.so \
-    postnotifications.so
+    postnotifications.so \
+    rdbloadsave.so
 
 .PHONY: all
 

--- a/tests/modules/rdbloadsave.c
+++ b/tests/modules/rdbloadsave.c
@@ -1,0 +1,158 @@
+#include "redismodule.h"
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <memory.h>
+#include <errno.h>
+
+
+
+int sanity(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
+
+    if (RedisModule_RdbLoad(NULL, 0) == REDISMODULE_OK || errno != EINVAL) {
+        RedisModule_ReplyWithError(ctx, "ERR null filename should fail");
+        return REDISMODULE_OK;
+    }
+
+    if (RedisModule_RdbLoad("dump.rdb", 1) == REDISMODULE_OK || errno != EINVAL) {
+        RedisModule_ReplyWithError(ctx, "ERR invalid flags should fail");
+        return REDISMODULE_OK;
+    }
+
+    if (RedisModule_RdbSave(NULL, 0) == REDISMODULE_OK || errno != EINVAL) {
+        RedisModule_ReplyWithError(ctx, "ERR null filename should fail");
+        return REDISMODULE_OK;
+    }
+
+    if (RedisModule_RdbSave("dump.rdb", 1) == REDISMODULE_OK || errno != EINVAL) {
+        RedisModule_ReplyWithError(ctx, "ERR invalid flags should fail");
+        return REDISMODULE_OK;
+    }
+
+    if (RedisModule_RdbLoad("dump.rdb", 0) == REDISMODULE_OK || errno != ENOENT) {
+        RedisModule_ReplyWithError(ctx, "ERR missing file should fail");
+        return REDISMODULE_OK;
+    }
+
+    if (RedisModule_RdbSave("dump.rdb", 0) != REDISMODULE_OK || errno != 0) {
+        RedisModule_ReplyWithError(ctx, "ERR rdbsave failed");
+        return REDISMODULE_OK;
+    }
+
+    if (RedisModule_RdbLoad("dump.rdb", 0) != REDISMODULE_OK || errno != 0) {
+        RedisModule_ReplyWithError(ctx, "ERR rdbload failed");
+        return REDISMODULE_OK;
+    }
+
+    RedisModule_ReplyWithSimpleString(ctx, "OK");
+    return REDISMODULE_OK;
+}
+
+int cmd_rdbsave(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    RedisModuleBlockedClient *bc = NULL;
+    RedisModuleCtx *reply_ctx = ctx;
+
+    if (argc != 3) {
+        RedisModule_WrongArity(ctx);
+        return REDISMODULE_OK;
+    }
+
+    long long blocking = 0;
+    if (RedisModule_StringToLongLong(argv[1], &blocking) != REDISMODULE_OK) {
+        RedisModule_ReplyWithError(ctx, "Invalid integer value");
+        return REDISMODULE_OK;
+    }
+
+    size_t len;
+    const char *filename = RedisModule_StringPtrLen(argv[2], &len);
+
+    char tmp[len + 1];
+    memcpy(tmp, filename, len);
+    tmp[len] = '\0';
+
+    if (blocking) {
+         bc = RedisModule_BlockClient(ctx, NULL, NULL, NULL, 0);
+         reply_ctx = RedisModule_GetThreadSafeContext(bc);
+    }
+
+    if (RedisModule_RdbSave(tmp, 0) != REDISMODULE_OK || errno != 0) {
+        RedisModule_ReplyWithError(reply_ctx, "ERR rdbsave failed");
+        goto out;
+    }
+
+    RedisModule_ReplyWithSimpleString(reply_ctx, "OK");
+
+out:
+    if (blocking) {
+        RedisModule_FreeThreadSafeContext(reply_ctx);
+        RedisModule_UnblockClient(bc, NULL);
+    }
+    return REDISMODULE_OK;
+}
+
+int cmd_rdbload(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    RedisModuleBlockedClient *bc = NULL;
+    RedisModuleCtx *reply_ctx = ctx;
+
+    if (argc != 3) {
+        RedisModule_WrongArity(ctx);
+        return REDISMODULE_OK;
+    }
+
+    long long blocking = 0;
+    if (RedisModule_StringToLongLong(argv[1], &blocking) != REDISMODULE_OK) {
+        RedisModule_ReplyWithError(ctx, "Invalid integer value");
+        return REDISMODULE_OK;
+    }
+
+    size_t len;
+    const char *filename = RedisModule_StringPtrLen(argv[2], &len);
+
+    char tmp[len + 1];
+    memcpy(tmp, filename, len);
+    tmp[len] = '\0';
+
+    printf("blocking %lld\n", blocking);
+
+    if (blocking) {
+        bc = RedisModule_BlockClient(ctx, NULL, NULL, NULL, 0);
+        reply_ctx = RedisModule_GetThreadSafeContext(bc);
+    }
+
+    if (RedisModule_RdbLoad(tmp, 0) != REDISMODULE_OK || errno != 0) {
+        RedisModule_ReplyWithError(reply_ctx, "ERR rdbload failed");
+        goto out;
+    }
+
+    RedisModule_ReplyWithSimpleString(reply_ctx, "OK");
+
+out:
+    if (blocking) {
+        RedisModule_FreeThreadSafeContext(reply_ctx);
+        RedisModule_UnblockClient(bc, NULL);
+    }
+    return REDISMODULE_OK;
+}
+
+int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
+
+    if (RedisModule_Init(ctx,"rdbloadsave",1,REDISMODULE_APIVER_1)
+        == REDISMODULE_ERR) return REDISMODULE_ERR;
+
+    /* Test basics. */
+    if (RedisModule_CreateCommand(ctx, "test.sanity", sanity, "", 0, 0, 0)
+                                  == REDISMODULE_ERR) return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx, "test.blocked_client_rdbsave",
+                                  cmd_rdbsave, "", 0, 0, 0)
+                                  == REDISMODULE_ERR) return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx, "test.blocked_client_rdbload",
+                                  cmd_rdbload, "", 0, 0, 0)
+                                  == REDISMODULE_ERR) return REDISMODULE_ERR;
+    return REDISMODULE_OK;
+}

--- a/tests/modules/rdbloadsave.c
+++ b/tests/modules/rdbloadsave.c
@@ -1,48 +1,43 @@
 #include "redismodule.h"
+
 #include <stdlib.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <memory.h>
 #include <errno.h>
 
-
-
+/* Sanity tests to verify inputs and return values. */
 int sanity(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     REDISMODULE_NOT_USED(argv);
     REDISMODULE_NOT_USED(argc);
 
+    /* NULL filename should fail. */
     if (RedisModule_RdbLoad(NULL, 0) == REDISMODULE_OK || errno != EINVAL) {
-        RedisModule_ReplyWithError(ctx, "ERR null filename should fail");
+        RedisModule_ReplyWithError(ctx, strerror(errno));
         return REDISMODULE_OK;
     }
 
+    /* Invalid flags should fail. */
     if (RedisModule_RdbLoad("dump.rdb", 1) == REDISMODULE_OK || errno != EINVAL) {
-        RedisModule_ReplyWithError(ctx, "ERR invalid flags should fail");
+        RedisModule_ReplyWithError(ctx, strerror(errno));
         return REDISMODULE_OK;
     }
 
-    if (RedisModule_RdbSave(NULL, 0) == REDISMODULE_OK || errno != EINVAL) {
-        RedisModule_ReplyWithError(ctx, "ERR null filename should fail");
-        return REDISMODULE_OK;
-    }
-
-    if (RedisModule_RdbSave("dump.rdb", 1) == REDISMODULE_OK || errno != EINVAL) {
-        RedisModule_ReplyWithError(ctx, "ERR invalid flags should fail");
-        return REDISMODULE_OK;
-    }
-
+    /* Missing file should fail. */
     if (RedisModule_RdbLoad("dump.rdb", 0) == REDISMODULE_OK || errno != ENOENT) {
-        RedisModule_ReplyWithError(ctx, "ERR missing file should fail");
+        RedisModule_ReplyWithError(ctx, strerror(errno));
         return REDISMODULE_OK;
     }
 
-    if (RedisModule_RdbSave("dump.rdb", 0) != REDISMODULE_OK || errno != 0) {
-        RedisModule_ReplyWithError(ctx, "ERR rdbsave failed");
+    /* Save RDB file. */
+    if (RedisModule_RdbSave("sanitytest.rdb", 0) != REDISMODULE_OK || errno != 0) {
+        RedisModule_ReplyWithError(ctx, strerror(errno));
         return REDISMODULE_OK;
     }
 
-    if (RedisModule_RdbLoad("dump.rdb", 0) != REDISMODULE_OK || errno != 0) {
-        RedisModule_ReplyWithError(ctx, "ERR rdbload failed");
+    /* Load the saved RDB file. */
+    if (RedisModule_RdbLoad("sanitytest.rdb", 0) != REDISMODULE_OK || errno != 0) {
+        RedisModule_ReplyWithError(ctx, strerror(errno));
         return REDISMODULE_OK;
     }
 
@@ -51,88 +46,77 @@ int sanity(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 }
 
 int cmd_rdbsave(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-    RedisModuleBlockedClient *bc = NULL;
-    RedisModuleCtx *reply_ctx = ctx;
 
-    if (argc != 3) {
+    if (argc != 2) {
         RedisModule_WrongArity(ctx);
         return REDISMODULE_OK;
     }
 
-    long long blocking = 0;
-    if (RedisModule_StringToLongLong(argv[1], &blocking) != REDISMODULE_OK) {
-        RedisModule_ReplyWithError(ctx, "Invalid integer value");
-        return REDISMODULE_OK;
-    }
-
     size_t len;
-    const char *filename = RedisModule_StringPtrLen(argv[2], &len);
+    const char *filename = RedisModule_StringPtrLen(argv[1], &len);
 
     char tmp[len + 1];
     memcpy(tmp, filename, len);
     tmp[len] = '\0';
 
-    if (blocking) {
-         bc = RedisModule_BlockClient(ctx, NULL, NULL, NULL, 0);
-         reply_ctx = RedisModule_GetThreadSafeContext(bc);
-    }
-
     if (RedisModule_RdbSave(tmp, 0) != REDISMODULE_OK || errno != 0) {
-        RedisModule_ReplyWithError(reply_ctx, "ERR rdbsave failed");
-        goto out;
+        RedisModule_ReplyWithError(ctx, strerror(errno));
+        return REDISMODULE_OK;
     }
 
-    RedisModule_ReplyWithSimpleString(reply_ctx, "OK");
+    RedisModule_ReplyWithSimpleString(ctx, "OK");
+    return REDISMODULE_OK;
+}
 
-out:
-    if (blocking) {
-        RedisModule_FreeThreadSafeContext(reply_ctx);
-        RedisModule_UnblockClient(bc, NULL);
+/* Fork before calling RM_RdbSave(). */
+int cmd_rdbsave_fork(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 2) {
+        RedisModule_WrongArity(ctx);
+        return REDISMODULE_OK;
     }
+
+    size_t len;
+    const char *filename = RedisModule_StringPtrLen(argv[1], &len);
+
+    char tmp[len + 1];
+    memcpy(tmp, filename, len);
+    tmp[len] = '\0';
+
+    int fork_child_pid = RedisModule_Fork(NULL, NULL);
+    if (fork_child_pid < 0) {
+        RedisModule_ReplyWithError(ctx, strerror(errno));
+        return REDISMODULE_OK;
+    } else if (fork_child_pid > 0) {
+        /* parent */
+        RedisModule_ReplyWithSimpleString(ctx, "OK");
+        return REDISMODULE_OK;
+    }
+
+    RedisModule_RdbSave(tmp, 0);
+    RedisModule_ExitFromChild(errno); /* RM_RdbSave() will set errno. */
+
     return REDISMODULE_OK;
 }
 
 int cmd_rdbload(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-    RedisModuleBlockedClient *bc = NULL;
-    RedisModuleCtx *reply_ctx = ctx;
-
-    if (argc != 3) {
+    if (argc != 2) {
         RedisModule_WrongArity(ctx);
         return REDISMODULE_OK;
     }
 
-    long long blocking = 0;
-    if (RedisModule_StringToLongLong(argv[1], &blocking) != REDISMODULE_OK) {
-        RedisModule_ReplyWithError(ctx, "Invalid integer value");
-        return REDISMODULE_OK;
-    }
-
     size_t len;
-    const char *filename = RedisModule_StringPtrLen(argv[2], &len);
+    const char *filename = RedisModule_StringPtrLen(argv[1], &len);
 
     char tmp[len + 1];
     memcpy(tmp, filename, len);
     tmp[len] = '\0';
 
-    printf("blocking %lld\n", blocking);
-
-    if (blocking) {
-        bc = RedisModule_BlockClient(ctx, NULL, NULL, NULL, 0);
-        reply_ctx = RedisModule_GetThreadSafeContext(bc);
-    }
-
     if (RedisModule_RdbLoad(tmp, 0) != REDISMODULE_OK || errno != 0) {
-        RedisModule_ReplyWithError(reply_ctx, "ERR rdbload failed");
-        goto out;
+        RedisModule_ReplyWithError(ctx, strerror(errno));
+        return REDISMODULE_OK;
     }
 
-    RedisModule_ReplyWithSimpleString(reply_ctx, "OK");
-
-out:
-    if (blocking) {
-        RedisModule_FreeThreadSafeContext(reply_ctx);
-        RedisModule_UnblockClient(bc, NULL);
-    }
+    RedisModule_ReplyWithSimpleString(ctx, "OK");
     return REDISMODULE_OK;
 }
 
@@ -140,19 +124,20 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     REDISMODULE_NOT_USED(argv);
     REDISMODULE_NOT_USED(argc);
 
-    if (RedisModule_Init(ctx,"rdbloadsave",1,REDISMODULE_APIVER_1)
-        == REDISMODULE_ERR) return REDISMODULE_ERR;
+    if (RedisModule_Init(ctx, "rdbloadsave", 1, REDISMODULE_APIVER_1) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
 
-    /* Test basics. */
-    if (RedisModule_CreateCommand(ctx, "test.sanity", sanity, "", 0, 0, 0)
-                                  == REDISMODULE_ERR) return REDISMODULE_ERR;
+    if (RedisModule_CreateCommand(ctx, "test.sanity", sanity, "", 0, 0, 0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
 
-    if (RedisModule_CreateCommand(ctx, "test.blocked_client_rdbsave",
-                                  cmd_rdbsave, "", 0, 0, 0)
-                                  == REDISMODULE_ERR) return REDISMODULE_ERR;
+    if (RedisModule_CreateCommand(ctx, "test.rdbsave", cmd_rdbsave, "", 0, 0, 0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
 
-    if (RedisModule_CreateCommand(ctx, "test.blocked_client_rdbload",
-                                  cmd_rdbload, "", 0, 0, 0)
-                                  == REDISMODULE_ERR) return REDISMODULE_ERR;
+    if (RedisModule_CreateCommand(ctx, "test.rdbsave_fork", cmd_rdbsave_fork, "", 0, 0, 0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx, "test.rdbload", cmd_rdbload, "", 0, 0, 0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
     return REDISMODULE_OK;
 }

--- a/tests/unit/moduleapi/rdbloadsave.tcl
+++ b/tests/unit/moduleapi/rdbloadsave.tcl
@@ -101,9 +101,9 @@ start_server {tags {"modules"}} {
         assert_equal OK [r test.rdbload bgsave.rdb]
 
         wait_for_condition 10 1000 {
-            [string match {*SIGUSR1*child*} [exec tail -20 < [srv 0 stdout]]]
+            [string match {*Background*saving*terminated*} [exec tail -20 < [srv 0 stdout]]]
         } else {
-            fail "Can't find 'SIGUSR1 child' in recent log lines"
+            fail "Can't find 'Background saving terminated' in recent log lines"
         }
 
         assert_equal v1 [r get k]

--- a/tests/unit/moduleapi/rdbloadsave.tcl
+++ b/tests/unit/moduleapi/rdbloadsave.tcl
@@ -14,7 +14,8 @@ start_server {tags {"modules"}} {
     test "Module rdbloadsave sanity" {
         r test.sanity
 
-        assert_error {*No such file*} {r test.rdbload sanity.rdb}
+        # Try to load non-existing file
+        assert_error {*Input/output error*} {r test.rdbload sanity.rdb}
 
         r set x 1
         assert_equal OK [r test.rdbsave sanity.rdb]
@@ -107,15 +108,6 @@ start_server {tags {"modules"}} {
         }
 
         assert_equal v1 [r get k]
-        r flushall
-        waitForBgsave r
-
-        # RM_RdbSave() should fail if there is already a fork saving into the
-        # same rdb file.
-        r set k v3
-        r bgsave
-        assert_error {*in*progress*} {r test.rdbsave dump.rdb}
-
         r flushall
         waitForBgsave r
         r config set rdb-key-save-delay 0

--- a/tests/unit/moduleapi/rdbloadsave.tcl
+++ b/tests/unit/moduleapi/rdbloadsave.tcl
@@ -60,6 +60,7 @@ start_server {tags {"modules"}} {
         # Enable the AOF
         r config set appendonly yes
         r config set auto-aof-rewrite-percentage 0 ; # Disable auto-rewrite.
+        waitForBgrewriteaof r
 
         r set k v1
         assert_equal OK [r test.rdbsave aoftest.rdb]

--- a/tests/unit/moduleapi/rdbloadsave.tcl
+++ b/tests/unit/moduleapi/rdbloadsave.tcl
@@ -11,49 +11,140 @@ start_server {tags {"modules"}} {
 
     r module load $testmodule
 
-    test "Module bgsave" {
-        r config set save ""
-        # 5000 keys with 1ms sleep per key should take 5 second
-        r config set rdb-key-save-delay 10
-        # r config set loading-process-events-interval-bytes 1024
-        populate 200000 a
-        r set x 111
-        #r bgsave
-        #assert_equal [s rdb_bgsave_in_progress] 1
-        assert_equal [r dbsize] 200001
+    test "Module rdbloadsave sanity" {
+        r test.sanity
 
-        assert_equal OK [r test.blocked_client_rdbsave 0 blabla.rdb]
+        assert_error {*No such file*} {r test.rdbload sanity.rdb}
+
+        r set x 1
+        assert_equal OK [r test.rdbsave sanity.rdb]
+
+        r flushdb
+        assert_equal OK [r test.rdbload sanity.rdb]
+        assert_equal 1 [r get x]
+    }
+
+    test "Module rdbloadsave test with pipelining" {
+        r config set save ""
+        r config set loading-process-events-interval-bytes 1024
+        r flushdb
+
+        populate 50000 a 128
+        r set x 111
+        assert_equal [r dbsize] 50001
+
+        assert_equal OK [r test.rdbsave blabla.rdb]
         r flushdb
         assert_equal [r dbsize] 0
 
-        r write [format_command test.blocked_client_rdbload 0 blabla.rdb]
+        # Send commands with pipeline. First command will call RM_RdbLoad() in
+        # the command callback. While loading RDB, Redis can go to networking to
+        # reply -LOADING. By sending commands in pipeline, we verify it doesn't
+        # cause a problem.
+        # e.g. Redis won't try to process next message of the current client
+        # while it is in the command callback.
+        r write [format_command test.rdbload blabla.rdb]
         r flush
         r write [format_command get x]
+        r write [format_command dbsize]
         r flush
+
         assert_equal OK [r read]
-        # assert_equal 111 [r read]
-        # assert_equal OK [r test.blocked_client_rdbload blabla.rdb]
-        # assert_equal [r dbsize] 2000001
-        # assert_equal [r get x] 111
+        assert_equal 111 [r read]
+        assert_equal 50001 [r read]
     }
 
-    test "Module sanity" {
-        r test.sanity
+    test "Module rdbloadsave with aof" {
+        r config set save ""
+
+        # Enable the AOF
+        r config set appendonly yes
+        r config set auto-aof-rewrite-percentage 0 ; # Disable auto-rewrite.
+
+        r set k v1
+        assert_equal OK [r test.rdbsave aoftest.rdb]
+
+        r set k v2
+        r config set rdb-key-save-delay 10000000
+        r bgrewriteaof
+
+        # RM_RdbLoad() should kill aof fork
+        assert_equal OK [r test.rdbload aoftest.rdb]
+
+        wait_for_condition 50 100 {
+            [string match {*Killing*AOF*child*} [exec tail -20 < [srv 0 stdout]]]
+        } else {
+            fail "Can't find 'Killing AOF child' in recent log lines"
+        }
+
+        # Verify the value in the loaded rdb
+        assert_equal v1 [r get k]
+
+        r flushdb
+        r config set rdb-key-save-delay 0
+        r config set appendonly no
     }
 
-    test "Module load unload" {
-        # assert_error {*rdbload*} {r test.blocked_client_rdbload unload.rdb}
-        # assert_equal OK [r test.blocked_client_rdbsave unload.rdb]
-        # assert_equal OK [r test.blocked_client_rdbload unload.rdb]
+    test "Module rdbloadsave with bgsave" {
+        r flushdb
+        r config set save ""
+
+        r set k v1
+        assert_equal OK [r test.rdbsave bgsave.rdb]
+
+        r set k v2
+        r config set rdb-key-save-delay 10000000
+        r bgsave
+
+        # RM_RdbLoad() should kill RDB fork
+        assert_equal OK [r test.rdbload bgsave.rdb]
+
+        wait_for_condition 10 1000 {
+            [string match {*SIGUSR1*child*} [exec tail -20 < [srv 0 stdout]]]
+        } else {
+            fail "Can't find 'SIGUSR1 child' in recent log lines"
+        }
+
+        assert_equal v1 [r get k]
+        r flushall
+        waitForBgsave r
+
+        # RM_RdbSave() should fail if there is already a fork saving into the
+        # same rdb file.
+        r set k v3
+        r bgsave
+        assert_error {*in*progress*} {r test.rdbsave dump.rdb}
+
+        r flushall
+        waitForBgsave r
+        r config set rdb-key-save-delay 0
     }
 
-    test "Module large state save" {
+    test "Module rdbloadsave calls rdbsave in a module fork" {
+        r flushdb
+        r config set save ""
+        r config set rdb-key-save-delay 3000000
 
+        r set k v1
+
+        # Module will call RM_Fork() before calling RM_RdbSave()
+        assert_equal OK [r test.rdbsave_fork rdbfork.rdb]
+        assert_equal [s module_fork_in_progress] 1
+
+        wait_for_condition 10 1000 {
+            [status r module_fork_in_progress] == "0"
+        } else {
+            fail "Module fork didn't finish"
+        }
+
+        r set k v2
+        assert_equal OK [r test.rdbload rdbfork.rdb]
+        assert_equal v1 [r get k]
+
+        r config set rdb-key-save-delay 0
     }
 
-
-
-    test "Unload the module - eventloop" {
+    test "Unload the module - rdbloadsave" {
         assert_equal {OK} [r module unload rdbloadsave]
     }
 }

--- a/tests/unit/moduleapi/rdbloadsave.tcl
+++ b/tests/unit/moduleapi/rdbloadsave.tcl
@@ -1,0 +1,59 @@
+set testmodule [file normalize tests/modules/rdbloadsave.so]
+
+start_server {tags {"modules"}} {
+    proc format_command {args} {
+        set cmd "*[llength $args]\r\n"
+        foreach a $args {
+            append cmd "$[string length $a]\r\n$a\r\n"
+        }
+        set _ $cmd
+    }
+
+    r module load $testmodule
+
+    test "Module bgsave" {
+        r config set save ""
+        # 5000 keys with 1ms sleep per key should take 5 second
+        r config set rdb-key-save-delay 10
+        # r config set loading-process-events-interval-bytes 1024
+        populate 200000 a
+        r set x 111
+        #r bgsave
+        #assert_equal [s rdb_bgsave_in_progress] 1
+        assert_equal [r dbsize] 200001
+
+        assert_equal OK [r test.blocked_client_rdbsave 0 blabla.rdb]
+        r flushdb
+        assert_equal [r dbsize] 0
+
+        r write [format_command test.blocked_client_rdbload 0 blabla.rdb]
+        r flush
+        r write [format_command get x]
+        r flush
+        assert_equal OK [r read]
+        # assert_equal 111 [r read]
+        # assert_equal OK [r test.blocked_client_rdbload blabla.rdb]
+        # assert_equal [r dbsize] 2000001
+        # assert_equal [r get x] 111
+    }
+
+    test "Module sanity" {
+        r test.sanity
+    }
+
+    test "Module load unload" {
+        # assert_error {*rdbload*} {r test.blocked_client_rdbload unload.rdb}
+        # assert_equal OK [r test.blocked_client_rdbsave unload.rdb]
+        # assert_equal OK [r test.blocked_client_rdbload unload.rdb]
+    }
+
+    test "Module large state save" {
+
+    }
+
+
+
+    test "Unload the module - eventloop" {
+        assert_equal {OK} [r module unload rdbloadsave]
+    }
+}


### PR DESCRIPTION
Add `RM_RdbLoad()` and `RM_RdbSave()` to load/save RDB files from the module API. 

In our use case, we have our clustering implementation as a module. As part of this implementation, the module needs to trigger RDB save operation at specific points. Also, this module delivers RDB files to other nodes (not using Redis' replication). When a node receives an RDB file, it should be able to load the RDB. Currently, there is no module API to save/load RDB files. 


This PR adds four new APIs:
```c
RedisModuleRdbStream *RM_RdbStreamCreateFromFile(const char *filename);
void RM_RdbStreamFree(RedisModuleRdbStream *stream);

int RM_RdbLoad(RedisModuleRdbStream *stream, int flags);
int RM_RdbSave(RedisModuleRdbStream *stream, int flags);
```

The first step is to create a `RedisModuleRdbStream` object. This PR provides a function to create RedisModuleRdbStream from the filename. (You can load/save RDB with the filename). In the future, this API can be extended if needed: 
e.g., `RM_RdbStreamCreateFromFd()`, `RM_RdbStreamCreateFromSocket()` to save/load RDB from an `fd` or a `socket`. 


Usage:
```c
/* Save RDB */
RedisModuleRdbStream *stream = RedisModule_RdbStreamCreateFromFile("exp.rdb");
RedisModule_RdbSave(stream, 0);
RedisModule_RdbStreamFree(stream);

/* Load RDB */
RedisModuleRdbStream *stream = RedisModule_RdbStreamCreateFromFile("exp.rdb");
RedisModule_RdbLoad(stream, 0);
RedisModule_RdbStreamFree(stream);
```
