### PR TITLE
POC listpack hfe

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1347,7 +1347,7 @@ void renameGenericCommand(client *c, int nx) {
     /* If hash with expiration on fields then remove it from global HFE DS and
      * keep next expiration time. Otherwise, dbDelete() will remove it from the
      * global HFE DS and we will lose the expiration time. */
-    if (o->type == OBJ_HASH && o->encoding == OBJ_ENCODING_HT) {
+    if (o->type == OBJ_HASH) {
         minHashExpireTime = hashTypeRemoveFromExpires(&c->db->hexpires, o);
         /* update its key reference to the new name */
         hashTypeRename(o, c->argv[2]->ptr);
@@ -1429,7 +1429,7 @@ void moveCommand(client *c) {
     /* If hash with expiration on fields, remove it from global HFE DS and keep
      * aside registered expiration time. Must be before deletion of the object.
      * hexpires (ebuckets) embed in stored items its structure. */
-    if (o->type == OBJ_HASH && o->encoding == OBJ_ENCODING_HT)
+    if (o->type == OBJ_HASH)
         hashExpireTime = hashTypeRemoveFromExpires(&src->hexpires, o);
 
     incrRefCount(o);

--- a/src/object.c
+++ b/src/object.c
@@ -338,7 +338,7 @@ void freeHashObject(robj *o) {
         dictRelease((dict*) o->ptr);
         break;
     case OBJ_ENCODING_LISTPACK:
-        lpFree(o->ptr);
+        freeHash(o->ptr);
         break;
     default:
         serverPanic("Unknown hash encoding type");

--- a/src/server.h
+++ b/src/server.h
@@ -3171,6 +3171,8 @@ int hashTypeSet(redisDb *db, robj *o, sds field, sds value, int flags);
 robj *hashTypeDup(robj *o, sds newkey, uint64_t *minHashExpire);
 uint64_t hashTypeRemoveFromExpires(ebuckets *hexpires, robj *o);
 void hashTypeAddToExpires(redisDb *db, robj *keyObj, robj *hashObj, uint64_t expireTime);
+/* TODO: Find a better place */
+void freeHash(void *ptr);
 
 /* Hash-Field data type (of t_hash.c) */
 hfield hfieldNew(const void *field, size_t fieldlen, int withExpireMeta);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -628,10 +628,12 @@ int hashTypeSet(redisDb *db, robj *o, sds field, sds value, int flags) {
                 /* Replace value */
                 zl = lpReplace(zl, &vptr, (unsigned char*)value, sdslen(value));
 
-                /* Clear TTL */
-                vptr = lpNext(zl, vptr);
-                serverAssert(vptr != NULL);
-                zl = lpReplaceInteger(zl, &vptr, HASH_LP_NO_TTL);
+                if (isHfe) {
+                    /* Clear TTL */
+                    vptr = lpNext(zl, vptr);
+                    serverAssert(vptr != NULL);
+                    zl = lpReplaceInteger(zl, &vptr, HASH_LP_NO_TTL);
+                }
             }
         }
 

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -141,46 +141,46 @@ start_server {tags {"hash expire"}} {
         assert_error {*invalid expire time*} {r hpexpire myhash [expr (1<<48) - [clock milliseconds] + 100 ] 1 f1}
     }
 
-    # test {Active/Lazy - deletes hash that all its fields got expired} {
-    #     for {set isActiveExp 0} {$isActiveExp <= 1} {incr isActiveExp} {
-    #         r debug set-active-expire $isActiveExp
-    #         r flushall
-#
-    #         set hash_sizes {1 15 16 17 31 32 33 40}
-    #         foreach h $hash_sizes {
-    #             for {set i 1} {$i <= $h} {incr i} {
-#
-    #                 # random expiration time
-    #                 r hset hrand$h f$i v$i
-    #                 r hpexpire hrand$h [expr {50 + int(rand() * 50)}] 1 f$i
-    #                 assert_equal 1 [r HEXISTS hrand$h f$i]
-#
-    #                 # same expiration time
-    #                 r hset same$h f$i v$i
-    #                 r hpexpire same$h 100 1 f$i
-    #                 assert_equal 1 [r HEXISTS same$h f$i]
-#
-    #                 # same expiration time
-    #                 r hset mix$h fieldWithoutExpire$i v$i
-    #                 r hset mix$h f$i v$i
-    #                 r hpexpire mix$h 100 1 f$i
-    #                 assert_equal 1 [r HEXISTS mix$h f$i]
-    #             }
-    #         }
-#
-    #         after 150
-#
-    #         # Verify that all fields got expired and keys got deleted
-    #         foreach h $hash_sizes {
-    #             for {set i 1} {$i <= $h} {incr i} {
-    #                 assert_equal 0 [r HEXISTS mix$h f$i]
-    #             }
-    #             assert_equal 0 [r EXISTS hrand$h]
-    #             assert_equal 0 [r EXISTS same$h]
-    #             assert_equal 1 [r EXISTS mix$h]
-    #         }
-    #     }
-    # }
+     test {Active/Lazy - deletes hash that all its fields got expired} {
+         for {set isActiveExp 0} {$isActiveExp <= 1} {incr isActiveExp} {
+             r debug set-active-expire $isActiveExp
+             r flushall
+
+             set hash_sizes {1 15 16 17 31 32 33 40}
+             foreach h $hash_sizes {
+                 for {set i 1} {$i <= $h} {incr i} {
+
+                     # random expiration time
+                     r hset hrand$h f$i v$i
+                     r hpexpire hrand$h [expr {50 + int(rand() * 50)}] 1 f$i
+                     assert_equal 1 [r HEXISTS hrand$h f$i]
+
+                     # same expiration time
+                     r hset same$h f$i v$i
+                     r hpexpire same$h 100 1 f$i
+                     assert_equal 1 [r HEXISTS same$h f$i]
+
+                     # same expiration time
+                     r hset mix$h fieldWithoutExpire$i v$i
+                     r hset mix$h f$i v$i
+                     r hpexpire mix$h 100 1 f$i
+                     assert_equal 1 [r HEXISTS mix$h f$i]
+                 }
+             }
+
+             after 150
+
+             # Verify that all fields got expired and keys got deleted
+             foreach h $hash_sizes {
+                 for {set i 1} {$i <= $h} {incr i} {
+                     assert_equal 0 [r HEXISTS mix$h f$i]
+                 }
+                 assert_equal 0 [r EXISTS hrand$h]
+                 assert_equal 0 [r EXISTS same$h]
+                 assert_equal 1 [r EXISTS mix$h]
+             }
+         }
+     }
 
     test {HPEXPIRE - Flushall deletes all pending expired fields} {
         r del myhash


### PR DESCRIPTION
POC implementation for listpack hash field expiration.

Currently, we keep `field name` and `value` pairs in listpack for the hash type. With this PR, if `hexpire` command is called on the key, it converts listpack layout to triplets to hold `field name`, `value` and `ttl` per field.
- Pros: 
  - If user is not using hfe on the key, there is no memory or CPU overhead. 
  - Implementation is relatively simple. 
- Cons: 
  - If a field does not have a TTL, we store zero as the ttl value . Zero is encoded as two bytes in the listpack. So, once we convert listpack to hold triplets, for the fields that don't have a TTL, it will be consuming those extra 2 bytes per item.


Open questions:
  1) Is there a case that we want to store zero as a valid ttl? I assumed if TTL is zero, field will be expired already and no need to store it. (so we can use it as "no-ttl" flag). 
  2) To detect if the listpack contains pairs or triplets, currently this PR uses pointer hack (sets lower bit of the robj->ptr): [link](https://github.com/tezc/redis/blob/34c49a5444835df1881a213b8e42b82c18730457/src/t_hash.c#L202)

   - One alternative would be allocating a struct for hash type and have a flag in it: 
    ```
    struct hash {
         unsigned char *lp;
         int isHfe;
    }
    ```
  Currently, robj->ptr directly holds listpack ptr. If we want to allocate above structure, it means, this is going to be 16 bytes overhead per key even if you don't use hash field expiration on the key. I feel like this would be the cleanest solution but it brings the overhead. 

- Instead of `OBJ_ENCODING_LISTPACK`, introduce another encoding to indicate listpack has triplets / ttls. Not sure if this is a better idea. 

Todo:
- hscan / hrandfield is missing 
- Convert lp to dict (with TTLs)
- rdb load / save is missing for the listpack with ttl. 
- Performance evaluation. Current implementation is naive. e.g. it iterates over all the items to find expired ones. Possibly, items can be stored ordered by TTL if this is going to improve the performance.  
- Adjust lpValidateIntegrity() / lpRandomPair() to accept triplets. 

