### PR TITLE
Dummy implementation of CLUSTER MIGRATION

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -62,6 +62,18 @@ ConnectionType *connTypeOfCluster(void) {
     return connectionTypeTcp();
 }
 
+int getSlotOrReply(client *c, robj *o) {
+    long long slot;
+
+    if (getLongLongFromObject(o,&slot) != C_OK ||
+        slot < 0 || slot >= CLUSTER_SLOTS)
+    {
+        addReplyError(c,"Invalid or out of range slot");
+        return -1;
+    }
+    return (int) slot;
+}
+
 /* -----------------------------------------------------------------------------
  * DUMP, RESTORE and MIGRATE commands
  * -------------------------------------------------------------------------- */

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -137,6 +137,7 @@ int clusterRedirectBlockedClientIfNeeded(client *c);
 void clusterRedirectClient(client *c, clusterNode *n, int hashslot, int error_code);
 void migrateCloseTimedoutSockets(void);
 int patternHashSlot(char *pattern, int length);
+int getSlotOrReply(client *c, robj *o);
 int isValidAuxString(char *s, unsigned int length);
 void migrateCommand(client *c);
 void clusterCommand(client *c);

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -56,10 +56,11 @@ static int checkOverlappingImport(SlotRange *req) {
  * - Ensures the current node is a master.
  * - Verifies all slots are in a STABLE state.
  * - Checks that slot ranges are well-formed and non-overlapping.
- * - Confirms all slots belong to a single remote source node.
+ * - Confirms all slots belong to a single source node.
+ * - Confirms no ongoing import operation that overlaps with the slot ranges.
  *
- * Returns the source node if validation succeeds; sets an error message otherwise.
- */
+ * Returns the source node if validation succeeds.
+ * Otherwise, returns NULL and sets 'err' variable. */
 static clusterNode *validateImportSlotRanges(list *slot_ranges, sds *err) {
     listNode *ln;
     listIter li;
@@ -97,6 +98,7 @@ static clusterNode *validateImportSlotRanges(list *slot_ranges, sds *err) {
             goto out;
         }
 
+        /* Ensure no import operation overlaps with this slot range. */
         if (checkOverlappingImport(sr) != C_OK) {
             *err = sdscatprintf(sdsempty(),
                                 "overlapping import exists for slot range: %d-%d",
@@ -291,7 +293,7 @@ static sds createSlotRangesStr(list *slot_ranges) {
 }
 
 /* CLUSTER MIGRATION STATUS
- *  - Reply: Map containing details of atomic slot migration links */
+ *  - Reply: Array of atomic slot migration links */
 static void clusterCommandMigrationStatus(client *c) {
     listIter li;
     listNode *ln;

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -15,13 +15,13 @@
 #define ASM_IMPORT  (1 << 1)
 #define ASM_MIGRATE (1 << 2)
 
-typedef struct asmLink {
+typedef struct asmTask {
     list *slot_ranges;            /* List of slot ranges for this migration operation */
     sds state;                    /* Dummy state str */
     char source[CLUSTER_NAMELEN]; /* Source node name */
     char dest[CLUSTER_NAMELEN];   /* Destination node name */
     int operation;                /* Either ASM_IMPORT or ASM_MIGRATE */
-} asmLink;
+} asmTask;
 
 /* Returns C_OK if there is no overlapping import operation in progress for the
  * given slot range. Otherwise, returns C_ERR */
@@ -31,7 +31,7 @@ static int checkOverlappingImport(SlotRange *req) {
 
     listRewind(server.cluster->asm_links, &li);
     while ((ln = listNext(&li)) != NULL) {
-        asmLink *link = ln->value;
+        asmTask *link = ln->value;
 
         /* Only import operations on the destination side can be cancelled. */
         if (link->operation != ASM_IMPORT ||
@@ -179,7 +179,7 @@ static void clusterCommandMigrationImport(client *c) {
     }
 
     /* Schedule slot migration operation */
-    asmLink *link = zcalloc(sizeof(*link));
+    asmTask *link = zcalloc(sizeof(*link));
     link->slot_ranges = slot_ranges;
     link->state = sdsnew("inprogress");
     link->operation = ASM_IMPORT;
@@ -199,7 +199,7 @@ static int cancelLinksForSlotRange(SlotRange *req_range) {
 
     listRewind(server.cluster->asm_links, &li);
     while ((ln = listNext(&li)) != NULL) {
-        asmLink *link = ln->value;
+        asmTask *link = ln->value;
 
         /* Only import operations on the destination side can be cancelled. */
         if (link->operation != ASM_IMPORT ||
@@ -302,7 +302,7 @@ static void clusterCommandMigrationStatus(client *c) {
 
     listRewind(server.cluster->asm_links, &li);
     while ((ln = listNext(&li)) != NULL) {
-        asmLink *link = ln->value;
+        asmTask *link = ln->value;
 
         addReplyMapLen(c, 5);
         addReplyBulkCString(c, "slots_range");

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -7,8 +7,333 @@
  * GNU Affero General Public License v3 (AGPLv3).
  */
 
+#include "server.h"
 #include "cluster_asm.h"
+#include "cluster.h"
+#include "cluster_legacy.h"
 
-int dummy(void) {
-    return 0;
+#define ASM_IMPORT  (1 << 1)
+#define ASM_MIGRATE (1 << 2)
+
+typedef struct asmLink {
+    list *slot_ranges;            /* List of slot ranges for this migration operation */
+    sds state;                    /* Dummy state str */
+    char source[CLUSTER_NAMELEN]; /* Source node name */
+    char dest[CLUSTER_NAMELEN];   /* Destination node name */
+    int operation;                /* Either ASM_IMPORT or ASM_MIGRATE */
+} asmLink;
+
+/* Returns C_OK if there is no overlapping import operation in progress for the
+ * given slot range. Otherwise, returns C_ERR */
+static int checkOverlappingImport(SlotRange *req) {
+    listIter li, sli;
+    listNode *ln, *sln;
+
+    listRewind(server.cluster->asm_links, &li);
+    while ((ln = listNext(&li)) != NULL) {
+        asmLink *link = ln->value;
+
+        /* Only import operations on the destination side can be cancelled. */
+        if (link->operation != ASM_IMPORT ||
+            strcasecmp(link->state, "inprogress") != 0)
+        {
+            continue;
+        }
+
+        listRewind(link->slot_ranges, &sli);
+        while ((sln = listNext(&sli)) != NULL) {
+            SlotRange *sr = sln->value;
+            /* Cancel if any slot range overlaps with the requested range. */
+            if (sr->first <= req->last && sr->last >= req->first)
+                return C_ERR;
+        }
+    }
+
+    return C_OK;
+}
+
+/* Validates the given slot ranges for a migration operation:
+ * - Ensures the current node is a master.
+ * - Verifies all slots are in a STABLE state.
+ * - Checks that slot ranges are well-formed and non-overlapping.
+ * - Confirms all slots belong to a single remote source node.
+ *
+ * Returns the source node if validation succeeds; sets an error message otherwise.
+ */
+static clusterNode *validateImportSlotRanges(list *slot_ranges, sds *err) {
+    listNode *ln;
+    listIter li;
+    clusterNode *source = NULL;
+    unsigned char *slots = zcalloc(CLUSTER_SLOTS);
+
+    *err = NULL;
+
+    /* Ensure this is a master node */
+    if (!clusterNodeIsMaster(server.cluster->myself)) {
+        *err = sdsnew("Slot migration not allowed on replica.");
+        goto out;
+    }
+
+    /* Ensure no manual migration is in progress. */
+    for (int i = 0; i < CLUSTER_SLOTS; i++) {
+        if (server.cluster->importing_slots_from[i] != NULL ||
+            server.cluster->migrating_slots_to[i] != NULL)
+        {
+            *err = sdsnew("Slot states must be STABLE to start a slot migration operation.");
+            goto out;
+        }
+    }
+
+    listRewind(slot_ranges, &li);
+    while ((ln = listNext(&li))) {
+        SlotRange *sr = ln->value;
+
+        /* Validate slot boundaries */
+        if (sr->first >= CLUSTER_SLOTS || sr->last >= CLUSTER_SLOTS ||
+            sr->first > sr->last)
+        {
+            *err = sdscatprintf(sdsempty(), "invalid slot range: %d-%d",
+                                sr->first, sr->last);
+            goto out;
+        }
+
+        if (checkOverlappingImport(sr) != C_OK) {
+            *err = sdscatprintf(sdsempty(),
+                                "overlapping import exists for slot range: %d-%d",
+                                sr->first, sr->last);
+            goto out;
+        }
+
+        /* Validate if we can start migration operation for this slot range. */
+        for (int i = sr->first; i <= sr->last; i++) {
+            if (server.cluster->slots[i] == NULL) {
+                *err = sdscatprintf(sdsempty(), "slot has no owner: %d", i);
+                goto out;
+            }
+
+            if (!source) {
+                source = server.cluster->slots[i];
+                if (source == server.cluster->myself) {
+                    *err = sdscatprintf(sdsempty(), "this node is already the owner of the slot: %d", i);
+                    goto out;
+                }
+            } else if (source != server.cluster->slots[i]) {
+                *err = sdsnew("slots belong to different source nodes");
+                goto out;
+            }
+
+            if (slots[i]++ != 0) {
+                *err = sdscatprintf(sdsempty(), "slot %d is given twice in different slot ranges", i);
+                goto out;
+            }
+        }
+    }
+
+out:
+    zfree(slots);
+    return *err ? NULL : source;
+}
+
+/* CLUSTER MIGRATION IMPORT <start-slot end-slot [start-slot end-slot ...]>
+ *
+ * Sent by operator to the destination node to start the migration. */
+static void clusterCommandMigrationImport(client *c) {
+    /* Validate slot range arg count */
+    int remaining = c->argc - 3;
+    if (remaining == 0 || remaining % 2 != 0) {
+        addReplyErrorArity(c);
+        return;
+    }
+
+    /* Parse slot ranges */
+    int first, last;
+    list *slot_ranges = listCreate();
+    listSetFreeMethod(slot_ranges, zfree);
+
+    for (int i = 3; i < c->argc; i += 2) {
+        if ((first = getSlotOrReply(c, c->argv[i])) == -1 ||
+            (last = getSlotOrReply(c, c->argv[i + 1])) == -1)
+        {
+            listRelease(slot_ranges);
+            return;
+        }
+
+        SlotRange *sr = zmalloc(sizeof(*sr));
+        sr->first = first;
+        sr->last = last;
+        listAddNodeTail(slot_ranges, sr);
+    }
+
+    sds err = NULL;
+    clusterNode *source;
+
+    /* Validate that the slot ranges are valid and that migration can be
+     * initiated for them. */
+    source = validateImportSlotRanges(slot_ranges, &err);
+    if (!source) {
+        addReplyErrorSds(c, err);
+        listRelease(slot_ranges);
+        return;
+    }
+
+    /* Schedule slot migration operation */
+    asmLink *link = zcalloc(sizeof(*link));
+    link->slot_ranges = slot_ranges;
+    link->state = sdsnew("inprogress");
+    link->operation = ASM_IMPORT;
+    memcpy(link->source, source->name, CLUSTER_NAMELEN);
+    memcpy(link->dest, server.cluster->myself->name, CLUSTER_NAMELEN);
+    listAddNodeTail(server.cluster->asm_links, link);
+
+    addReply(c, shared.ok);
+}
+
+/* Cancel atomic slot migration operations that overlap with the given slot
+ * range. Returns the number of cancelled operations. */
+static int cancelLinksForSlotRange(SlotRange *req_range) {
+    int num_cancelled = 0;
+    listIter li, sli;
+    listNode *ln, *sln;
+
+    listRewind(server.cluster->asm_links, &li);
+    while ((ln = listNext(&li)) != NULL) {
+        asmLink *link = ln->value;
+
+        /* Only import operations on the destination side can be cancelled. */
+        if (link->operation != ASM_IMPORT ||
+            strcasecmp(link->state, "inprogress") != 0)
+        {
+            continue;
+        }
+
+        listRewind(link->slot_ranges, &sli);
+        while ((sln = listNext(&sli)) != NULL) {
+            SlotRange *sr = sln->value;
+            /* Cancel if any slot range overlaps with the requested range. */
+            if (sr->first <= req_range->last && sr->last >= req_range->first) {
+                link->state = sdscpy(link->state, "cancelled");
+                num_cancelled++;
+                break;
+            }
+        }
+    }
+    return num_cancelled;
+}
+
+/* CLUSTER MIGRATION CANCEL <start-slot end-slot [start-slot end-slot ...]>
+ *   - Reply: Number of cancelled operations
+ *
+ * Cancels import operations that overlap with the specified slot ranges.
+ * Multiple operations may be cancelled. */
+static void clusterCommandMigrationCancel(client *c) {
+    int remaining, first, last;
+    int num_cancelled = 0;
+    listIter li;
+    listNode *ln;
+    list *slot_ranges;
+
+    /* Validate slot range arg count */
+    remaining = c->argc - 3;
+    if (remaining == 0 || remaining % 2 != 0) {
+        addReplyErrorArity(c);
+        return;
+    }
+
+    slot_ranges = listCreate();
+    listSetFreeMethod(slot_ranges, zfree);
+
+    /* Parse slot ranges into the list */
+    for (int i = 3; i < c->argc; i += 2) {
+        if ((first = getSlotOrReply(c, c->argv[i])) == -1 ||
+            (last = getSlotOrReply(c, c->argv[i + 1])) == -1)
+        {
+            listRelease(slot_ranges);
+            return;
+        }
+
+        if (first > last) {
+            addReplyErrorFormat(c, "invalid slot range: %d-%d", first, last);
+            listRelease(slot_ranges);
+            return;
+        }
+
+        SlotRange *sr = zmalloc(sizeof(*sr));
+        sr->first = first;
+        sr->last = last;
+        listAddNodeTail(slot_ranges, sr);
+    }
+
+    /* Cancel asm operations that overlaps with the slot ranges. */
+    listRewind(slot_ranges, &li);
+    while ((ln = listNext(&li)) != NULL) {
+        num_cancelled += cancelLinksForSlotRange(ln->value);
+    }
+
+    addReplyLongLong(c, num_cancelled);
+    listRelease(slot_ranges);
+}
+
+/* Create a slot range string in the format of: "1000-2000 3000-4000 ..." */
+static sds createSlotRangesStr(list *slot_ranges) {
+    listNode *ln;
+    listIter li;
+    sds s = sdsempty();
+
+    listRewind(slot_ranges, &li);
+    while ((ln = listNext(&li)) != NULL) {
+        SlotRange *range = ln->value;
+        s = sdscatprintf(s, "%d-%d ", range->first, range->last);
+    }
+    sdssetlen(s, sdslen(s) - 1);
+    s[sdslen(s)] = '\0';
+
+    return s;
+}
+
+/* CLUSTER MIGRATION STATUS
+ *  - Reply: Map containing details of atomic slot migration links */
+static void clusterCommandMigrationStatus(client *c) {
+    listIter li;
+    listNode *ln;
+
+    addReplyArrayLen(c, listLength(server.cluster->asm_links));
+
+    listRewind(server.cluster->asm_links, &li);
+    while ((ln = listNext(&li)) != NULL) {
+        asmLink *link = ln->value;
+
+        addReplyMapLen(c, 5);
+        addReplyBulkCString(c, "slots_range");
+        addReplyBulkSds(c, createSlotRangesStr(link->slot_ranges));
+        addReplyBulkCString(c, "source");
+        addReplyBulkCBuffer(c, link->source, CLUSTER_NAMELEN);
+        addReplyBulkCString(c, "dest");
+        addReplyBulkCBuffer(c, link->dest, CLUSTER_NAMELEN);
+        addReplyBulkCString(c, "operation");
+        addReplyBulkCString(c, link->operation == ASM_IMPORT ? "importing" : "migrating");
+        addReplyBulkCString(c, "state");
+        addReplyBulkCString(c, link->state);
+    }
+}
+
+/* CLUSTER MIGRATION
+ *      <IMPORT start-slot end-slot [start-slot end-slot ...] |
+ *       STATUS |
+ *       CANCEL start-slot end-slot [start-slot end-slot ...]>
+ * */
+void clusterMigrationCommand(client *c) {
+    if (c->argc < 3) {
+        addReplyErrorArity(c);
+        return;
+    }
+
+    if (strcasecmp(c->argv[2]->ptr, "import") == 0) {
+        clusterCommandMigrationImport(c);
+    } else if (strcasecmp(c->argv[2]->ptr, "status") == 0) {
+        clusterCommandMigrationStatus(c);
+    } else if (strcasecmp(c->argv[2]->ptr, "cancel") == 0) {
+        clusterCommandMigrationCancel(c);
+    } else {
+        addReplyError(c, "unknown argument");
+    }
 }

--- a/src/cluster_asm.h
+++ b/src/cluster_asm.h
@@ -10,5 +10,7 @@
 #ifndef CLUSTER_ASM_H
 #define CLUSTER_ASM_H
 
+void clusterMigrationCommand(client *c);
+
 #endif
 

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -20,6 +20,7 @@
 #include "server.h"
 #include "cluster.h"
 #include "cluster_legacy.h"
+#include "cluster_asm.h"
 #include "endianconv.h"
 #include "connection.h"
 
@@ -969,6 +970,7 @@ void clusterInit(void) {
     server.cluster->failover_auth_epoch = 0;
     server.cluster->cant_failover_reason = CLUSTER_CANT_FAILOVER_NONE;
     server.cluster->lastVoteEpoch = 0;
+    server.cluster->asm_links = listCreate();
 
     /* Initialize stats */
     for (int i = 0; i < CLUSTERMSG_TYPE_COUNT; i++) {
@@ -5597,18 +5599,6 @@ const char *clusterGetMessageTypeString(int type) {
     return "unknown";
 }
 
-int getSlotOrReply(client *c, robj *o) {
-    long long slot;
-
-    if (getLongLongFromObject(o,&slot) != C_OK ||
-        slot < 0 || slot >= CLUSTER_SLOTS)
-    {
-        addReplyError(c,"Invalid or out of range slot");
-        return -1;
-    }
-    return (int) slot;
-}
-
 int checkSlotAssignmentsOrReply(client *c, unsigned char *slots, int del, int start_slot, int end_slot) {
     int slot;
     for (slot = start_slot; slot <= end_slot; slot++) {
@@ -6409,6 +6399,8 @@ int clusterCommandSpecial(client *c) {
     } else if (!strcasecmp(c->argv[1]->ptr,"links") && c->argc == 2) {
         /* CLUSTER LINKS */
         addReplyClusterLinksDescription(c);
+    } else if (!strcasecmp(c->argv[1]->ptr, "migration")) {
+        clusterMigrationCommand(c);
     } else {
         return 0;
     }

--- a/src/cluster_legacy.h
+++ b/src/cluster_legacy.h
@@ -377,6 +377,9 @@ struct clusterState {
      * stops claiming the slot. This prevents spreading incorrect information (that
      * source still owns the slot) using UPDATE messages. */
     unsigned char owner_not_claiming_slot[CLUSTER_SLOTS / 8];
+
+    /* Atomic slot migration */
+    list *asm_links;
 };
 
 

--- a/src/commands.def
+++ b/src/commands.def
@@ -683,6 +683,47 @@ struct COMMAND_ARG CLUSTER_MEET_Args[] = {
 {MAKE_ARG("cluster-bus-port",ARG_TYPE_INTEGER,-1,NULL,NULL,"4.0.0",CMD_ARG_OPTIONAL,0,NULL)},
 };
 
+/********** CLUSTER MIGRATION ********************/
+
+#ifndef SKIP_CMD_HISTORY_TABLE
+/* CLUSTER MIGRATION history */
+#define CLUSTER_MIGRATION_History NULL
+#endif
+
+#ifndef SKIP_CMD_TIPS_TABLE
+/* CLUSTER MIGRATION tips */
+#define CLUSTER_MIGRATION_Tips NULL
+#endif
+
+#ifndef SKIP_CMD_KEY_SPECS_TABLE
+/* CLUSTER MIGRATION key specs */
+#define CLUSTER_MIGRATION_Keyspecs NULL
+#endif
+
+/* CLUSTER MIGRATION condition import argument table */
+struct COMMAND_ARG CLUSTER_MIGRATION_condition_import_Subargs[] = {
+{MAKE_ARG("start-slot",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("end-slot",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+};
+
+/* CLUSTER MIGRATION condition cancel argument table */
+struct COMMAND_ARG CLUSTER_MIGRATION_condition_cancel_Subargs[] = {
+{MAKE_ARG("start-slot",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("end-slot",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+};
+
+/* CLUSTER MIGRATION condition argument table */
+struct COMMAND_ARG CLUSTER_MIGRATION_condition_Subargs[] = {
+{MAKE_ARG("import",ARG_TYPE_BLOCK,-1,"IMPORT",NULL,NULL,CMD_ARG_MULTIPLE,2,NULL),.subargs=CLUSTER_MIGRATION_condition_import_Subargs},
+{MAKE_ARG("cancel",ARG_TYPE_BLOCK,-1,"CANCEL",NULL,NULL,CMD_ARG_MULTIPLE,2,NULL),.subargs=CLUSTER_MIGRATION_condition_cancel_Subargs},
+{MAKE_ARG("status",ARG_TYPE_PURE_TOKEN,-1,"STATUS",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+};
+
+/* CLUSTER MIGRATION argument table */
+struct COMMAND_ARG CLUSTER_MIGRATION_Args[] = {
+{MAKE_ARG("condition",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,3,NULL),.subargs=CLUSTER_MIGRATION_condition_Subargs},
+};
+
 /********** CLUSTER MYID ********************/
 
 #ifndef SKIP_CMD_HISTORY_TABLE
@@ -965,6 +1006,7 @@ struct COMMAND_STRUCT CLUSTER_Subcommands[] = {
 {MAKE_CMD("keyslot","Returns the hash slot for a key.","O(N) where N is the number of bytes in the key","3.0.0",CMD_DOC_NONE,NULL,NULL,"cluster",COMMAND_GROUP_CLUSTER,CLUSTER_KEYSLOT_History,0,CLUSTER_KEYSLOT_Tips,0,clusterCommand,3,CMD_STALE,0,CLUSTER_KEYSLOT_Keyspecs,0,NULL,1),.args=CLUSTER_KEYSLOT_Args},
 {MAKE_CMD("links","Returns a list of all TCP links to and from peer nodes.","O(N) where N is the total number of Cluster nodes","7.0.0",CMD_DOC_NONE,NULL,NULL,"cluster",COMMAND_GROUP_CLUSTER,CLUSTER_LINKS_History,0,CLUSTER_LINKS_Tips,1,clusterCommand,2,CMD_STALE,0,CLUSTER_LINKS_Keyspecs,0,NULL,0)},
 {MAKE_CMD("meet","Forces a node to handshake with another node.","O(1)","3.0.0",CMD_DOC_NONE,NULL,NULL,"cluster",COMMAND_GROUP_CLUSTER,CLUSTER_MEET_History,1,CLUSTER_MEET_Tips,0,clusterCommand,-4,CMD_NO_ASYNC_LOADING|CMD_ADMIN|CMD_STALE,0,CLUSTER_MEET_Keyspecs,0,NULL,3),.args=CLUSTER_MEET_Args},
+{MAKE_CMD("migration","Start, monitor and cancel slot migration.","O(N) where N is the total number of the slots between the start slot and end slot arguments.","9.0.0",CMD_DOC_NONE,NULL,NULL,"cluster",COMMAND_GROUP_CLUSTER,CLUSTER_MIGRATION_History,0,CLUSTER_MIGRATION_Tips,0,clusterCommand,-3,CMD_NO_ASYNC_LOADING|CMD_ADMIN|CMD_STALE,0,CLUSTER_MIGRATION_Keyspecs,0,NULL,1),.args=CLUSTER_MIGRATION_Args},
 {MAKE_CMD("myid","Returns the ID of a node.","O(1)","3.0.0",CMD_DOC_NONE,NULL,NULL,"cluster",COMMAND_GROUP_CLUSTER,CLUSTER_MYID_History,0,CLUSTER_MYID_Tips,0,clusterCommand,2,CMD_STALE,0,CLUSTER_MYID_Keyspecs,0,NULL,0)},
 {MAKE_CMD("myshardid","Returns the shard ID of a node.","O(1)","7.2.0",CMD_DOC_NONE,NULL,NULL,"cluster",COMMAND_GROUP_CLUSTER,CLUSTER_MYSHARDID_History,0,CLUSTER_MYSHARDID_Tips,1,clusterCommand,2,CMD_STALE,0,CLUSTER_MYSHARDID_Keyspecs,0,NULL,0)},
 {MAKE_CMD("nodes","Returns the cluster configuration for a node.","O(N) where N is the total number of Cluster nodes","3.0.0",CMD_DOC_NONE,NULL,NULL,"cluster",COMMAND_GROUP_CLUSTER,CLUSTER_NODES_History,0,CLUSTER_NODES_Tips,1,clusterCommand,2,CMD_STALE,0,CLUSTER_NODES_Keyspecs,0,NULL,0)},

--- a/src/commands/cluster-migration.json
+++ b/src/commands/cluster-migration.json
@@ -1,0 +1,64 @@
+{
+    "MIGRATION": {
+        "summary": "Start, monitor and cancel slot migration.",
+        "complexity": "O(N) where N is the total number of the slots between the start slot and end slot arguments.",
+        "group": "cluster",
+        "since": "9.0.0",
+        "arity": -3,
+        "container": "CLUSTER",
+        "function": "clusterCommand",
+        "command_flags": [
+            "NO_ASYNC_LOADING",
+            "ADMIN",
+            "STALE"
+        ],
+        "arguments": [
+            {
+                "name": "condition",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "token": "IMPORT",
+                        "name": "import",
+                        "type": "block",
+                        "multiple": true,
+                        "arguments": [
+                            {
+                                "name": "start-slot",
+                                "type": "integer"
+                            },
+                            {
+                                "name": "end-slot",
+                                "type": "integer"
+                            }
+                        ]
+                    },
+                    {
+                        "token": "CANCEL",
+                        "name": "cancel",
+                        "type": "block",
+                        "multiple": true,
+                        "arguments": [
+                            {
+                                "name": "start-slot",
+                                "type": "integer"
+                            },
+                            {
+                                "name": "end-slot",
+                                "type": "integer"
+                            }
+                        ]
+                    },
+                    {
+                        "token": "STATUS",
+                        "name": "status",
+                        "type": "pure-token"
+                    }
+                ]
+            }
+        ],
+        "reply_schema": {
+            "const": "OK"
+        }
+    }
+}

--- a/src/commands/cluster-migration.json
+++ b/src/commands/cluster-migration.json
@@ -89,7 +89,7 @@
                                         "const": "importing"
                                     },
                                     {
-                                        "type": "migrating"
+                                        "const": "migrating"
                                     }
                                 ]
                             },

--- a/src/commands/cluster-migration.json
+++ b/src/commands/cluster-migration.json
@@ -58,7 +58,48 @@
             }
         ],
         "reply_schema": {
-            "const": "OK"
+            "oneOf": [
+                {
+                    "description": "Reply to CLUSTER STATUS.",
+                    "const": "OK"
+                },
+                {
+                    "description": "Reply to CLUSTER CANCEL, number of cancelled migration operations",
+                    "type": "integer"
+                },
+                {
+                    "description": "Reply to CLUSTER STATUS, array of migration operation details.",
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "slots_range": {
+                                "type": "string"
+                            },
+                            "source": {
+                                "type": "string"
+                            },
+                            "dest": {
+                                "type": "string"
+                            },
+                            "operation": {
+                                "oneOf": [
+                                    {
+                                        "const": "importing"
+                                    },
+                                    {
+                                        "type": "migrating"
+                                    }
+                                ]
+                            },
+                            "state": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     }
 }

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -1,0 +1,68 @@
+start_cluster 3 3 {tags {external:skip cluster}} {
+    test "Test IMPORT input validation" {
+        # Invalid slot range
+        assert_error {*wrong number of arguments*} {R 0 CLUSTER MIGRATION IMPORT}
+        assert_error {*wrong number of arguments*} {R 0 CLUSTER MIGRATION IMPORT 100}
+        assert_error {*wrong number of arguments*} {R 0 CLUSTER MIGRATION IMPORT 100 200 300}
+        assert_error {*invalid slot range*} {R 0 CLUSTER MIGRATION IMPORT 200 100}
+        assert_error {*out of range slot*} {R 0 CLUSTER MIGRATION IMPORT 17000 18000}
+        assert_error {*out of range slot*} {R 0 CLUSTER MIGRATION IMPORT 14000 18000}
+        assert_error {*out of range slot*} {R 0 CLUSTER MIGRATION IMPORT -1 0}
+        assert_error {*out of range slot*} {R 0 CLUSTER MIGRATION IMPORT sd sd}
+
+        assert_error {*already the owner of the slot*} {R 0 CLUSTER MIGRATION IMPORT 100 200}
+    }
+
+    test "Test IMPORT not allowed on replica" {
+        assert_error {* not allowed on replica*} {R 4 CLUSTER MIGRATION IMPORT 100 200}
+    }
+
+    test "Test IMPORT not allowed during manual migration" {
+        set dst_id [R 1 CLUSTER MYID]
+
+        # Set a slot to IMPORTING
+        R 0 CLUSTER SETSLOT 15000 IMPORTING $dst_id
+        assert_error {*must be STABLE to start*slot migration*} {R 0 CLUSTER MIGRATION IMPORT 100 200}
+        # Revert the change
+        R 0 CLUSTER SETSLOT 15000 STABLE
+
+        # Same test with setting a slot to MIGRATING
+        R 0 CLUSTER SETSLOT 5000 MIGRATING $dst_id
+        assert_error {*must be STABLE to start*slot migration*} {R 0 CLUSTER MIGRATION IMPORT 100 200}
+        # Revert the change
+        R 0 CLUSTER SETSLOT 5000 STABLE
+    }
+
+    test "Test IMPORT not allowed if the node is already the owner" {
+        assert_error {*already the owner of the slot: 100*} {R 0 CLUSTER MIGRATION IMPORT 100 100}
+    }
+
+    test "Test IMPORT not allowed for a slot without an owner" {
+        # Slot will have no owner
+        R 0 CLUSTER DELSLOTS 5000
+
+        assert_error {*slot has no owner: 5000*} {R 0 CLUSTER MIGRATION IMPORT 5000 5000}
+
+        # Revert the change
+        R 0 CLUSTER ADDSLOTS 5000
+    }
+
+    test "Test IMPORT not allowed if slot ranges belong to different nodes" {
+        assert_error {*slots belong to different source nodes*} {R 0 CLUSTER MIGRATION IMPORT 7000 15000}
+        assert_error {*slots belong to different source nodes*} {R 0 CLUSTER MIGRATION IMPORT 7000 8000 14000 15000}
+    }
+
+    test "Test IMPORT not allowed if slot is given multiple times" {
+        assert_error {*slot*is given twice in different slot ranges*} {R 0 CLUSTER MIGRATION IMPORT 7000 8000 8000 9000}
+        assert_error {*slot*is given twice in different slot ranges*} {R 0 CLUSTER MIGRATION IMPORT 7000 8000 7900 9000}
+    }
+
+    test "Test IMPORT not allowed if there is an overlapping import" {
+        R 0 CLUSTER MIGRATION IMPORT 7000 8000
+        assert_error {*overlapping import exists*} {R 0 CLUSTER MIGRATION IMPORT 8000 9000}
+        assert_error {*overlapping import exists*} {R 0 CLUSTER MIGRATION IMPORT 7500 8500}
+        assert_error {*overlapping import exists*} {R 0 CLUSTER MIGRATION IMPORT 6000 7000}
+        assert_error {*overlapping import exists*} {R 0 CLUSTER MIGRATION IMPORT 6500 7500}
+    }
+
+}


### PR DESCRIPTION
Dummy implementation for these commands: 

- `CLUSTER MIGRATION IMPORT start-slot end-slot [start-slot end-slot ...]`
- `CLUSTER MIGRATION STATUS`
- `CLUSTER MIGRATION CANCEL start-slot end-slot [start-slot end-slot ...]`

The implementation primarily handles command parsing. Import requests are simply queued without triggering any action.

@ShooterIT this is a quick implementation to get an idea about the API. Let's see if we are comfortable with this. 
Please notice that CANCEL may cancel multiple operations and the reply is number of cancelled operation. I feel like this makes more sense. Let me know what you think. 