### PR TITLE
Refactor to use slot range array

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1575,32 +1575,32 @@ void replySlotsFlushAndFree(client *c, slotRangeArray *sra) {
     addReplyArrayLen(c, sra->num_ranges);
     for (int i = 0 ; i < sra->num_ranges ; i++) {
         addReplyArrayLen(c, 2);
-        addReplyLongLong(c, sra->ranges[i].start_slot);
-        addReplyLongLong(c, sra->ranges[i].end_slot);
+        addReplyLongLong(c, sra->ranges[i].start);
+        addReplyLongLong(c, sra->ranges[i].end);
     }
     zfree(sra);
 }
 
 /* Checks that slot ranges are well-formed and non-overlapping. */
 int validateSlotRanges(slotRangeArray *sra, sds *err) {
-    unsigned char *slots[CLUSTER_SLOTS] = {0};
+    unsigned char slots[CLUSTER_SLOTS] = {0};
 
     for (int i = 0; i < sra->num_ranges; i++) {
-        if (sra->ranges[i].start_slot >= CLUSTER_SLOTS ||
-            sra->ranges[i].end_slot >= CLUSTER_SLOTS)
+        if (sra->ranges[i].start >= CLUSTER_SLOTS ||
+            sra->ranges[i].end >= CLUSTER_SLOTS)
         {
             *err = sdscatprintf(sdsempty(), "slot range is out of range: %d-%d",
-                                sra->ranges[i].start_slot, sra->ranges[i].end_slot);
+                                sra->ranges[i].start, sra->ranges[i].end);
             return C_ERR;
         }
 
-        if (sra->ranges[i].start_slot > sra->ranges[i].end_slot) {
+        if (sra->ranges[i].start > sra->ranges[i].end) {
             *err = sdscatprintf(sdsempty(), "start slot number %d is greater than end slot number %d",
-                                sra->ranges[i].start_slot, sra->ranges[i].end_slot);
+                                sra->ranges[i].start, sra->ranges[i].end);
             return C_ERR;
         }
 
-        for (int j = sra->ranges[i].start_slot; j <= sra->ranges[i].end_slot; j++) {
+        for (int j = sra->ranges[i].start; j <= sra->ranges[i].end; j++) {
             if (slots[j]) {
                 *err = sdscatprintf(sdsempty(), "Slot %d specified multiple times", j);
                 return C_ERR;
@@ -1613,7 +1613,7 @@ int validateSlotRanges(slotRangeArray *sra, sds *err) {
 
 /* Parse slot ranges from the command arguments. Returns NULL on error. */
 slotRangeArray *parseSlotRangesOrReply(client *c, int argc, int pos) {
-    int start_slot, end_slot, count;
+    int start, end, count;
     slotRangeArray *sra;
 
     serverAssert(pos <= argc);
@@ -1623,14 +1623,14 @@ slotRangeArray *parseSlotRangesOrReply(client *c, int argc, int pos) {
     sra = zcalloc(sizeof(*sra) + count * sizeof(slotRange));
 
     for (int j = pos; j < argc; j += 2) {
-        if ((start_slot = getSlotOrReply(c, c->argv[j])) == -1 ||
-            (end_slot = getSlotOrReply(c, c->argv[j + 1])) == -1)
+        if ((start = getSlotOrReply(c, c->argv[j])) == -1 ||
+            (end = getSlotOrReply(c, c->argv[j + 1])) == -1)
         {
             zfree(sra);
             return NULL;
         }
-        sra->ranges[sra->num_ranges].start_slot = start_slot;
-        sra->ranges[sra->num_ranges].end_slot = end_slot;
+        sra->ranges[sra->num_ranges].start = start;
+        sra->ranges[sra->num_ranges].end = end;
         sra->num_ranges++;
     }
 
@@ -1688,7 +1688,7 @@ void sflushCommand(client *c) {
 
     for (int i = 0; i < slot_ranges->num_ranges; i++) {
         slotRange *sr = &slot_ranges->ranges[i];
-        for (int j = sr->start_slot; j <= sr->end_slot; j++)
+        for (int j = sr->start; j <= sr->end; j++)
             slotsToFlushRq[j] = 1;
     }
     zfree(slot_ranges);
@@ -1711,12 +1711,12 @@ void sflushCommand(client *c) {
             }
 
             if (!inSlotRange) { /* If start another slot range */
-                sflush->ranges[sflush->num_ranges].start_slot = i;
+                sflush->ranges[sflush->num_ranges].start = i;
                 inSlotRange = 1;
             }
         } else {
             if (inSlotRange) { /* If end another slot range */
-                sflush->ranges[sflush->num_ranges++].end_slot = i - 1;
+                sflush->ranges[sflush->num_ranges++].end = i - 1;
                 inSlotRange = 0;
                 /* If reached 'sflush' capacity, double the capacity */
                 if (sflush->num_ranges >= capacity) {
@@ -1728,7 +1728,7 @@ void sflushCommand(client *c) {
     }
 
     /* Update last pair if last cluster slot is also end of last range */
-    if (inSlotRange) sflush->ranges[sflush->num_ranges++].end_slot = CLUSTER_SLOTS - 1;
+    if (inSlotRange) sflush->ranges[sflush->num_ranges++].end = CLUSTER_SLOTS - 1;
 
     /* Flush selected slots. If not flush as blocking async, then reply immediately */
     if (flushCommandCommon(c, FLUSH_TYPE_SLOTS, flags, sflush) == 0)

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1617,6 +1617,8 @@ slotRangeArray *parseSlotRangesOrReply(client *c, int argc, int pos) {
     slotRangeArray *sra;
 
     serverAssert(pos <= argc);
+    serverAssert((argc - pos) % 2 == 0);
+
     count = (argc - pos) / 2;
     sra = zcalloc(sizeof(*sra) + count * sizeof(slotRange));
 

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1571,14 +1571,74 @@ void readonlyCommand(client *c) {
     addReply(c,shared.ok);
 }
 
-void replySlotsFlushAndFree(client *c, SlotsFlush *sflush) {
-    addReplyArrayLen(c, sflush->numRanges);
-    for (int i = 0 ; i < sflush->numRanges ; i++) {
+void replySlotsFlushAndFree(client *c, slotRangeArray *sra) {
+    addReplyArrayLen(c, sra->num_ranges);
+    for (int i = 0 ; i < sra->num_ranges ; i++) {
         addReplyArrayLen(c, 2);
-        addReplyLongLong(c, sflush->ranges[i].first);
-        addReplyLongLong(c, sflush->ranges[i].last);
+        addReplyLongLong(c, sra->ranges[i].start_slot);
+        addReplyLongLong(c, sra->ranges[i].end_slot);
     }
-    zfree(sflush);
+    zfree(sra);
+}
+
+/* Checks that slot ranges are well-formed and non-overlapping. */
+int validateSlotRanges(slotRangeArray *sra, sds *err) {
+    unsigned char *slots[CLUSTER_SLOTS] = {0};
+
+    for (int i = 0; i < sra->num_ranges; i++) {
+        if (sra->ranges[i].start_slot >= CLUSTER_SLOTS ||
+            sra->ranges[i].end_slot >= CLUSTER_SLOTS)
+        {
+            *err = sdscatprintf(sdsempty(), "slot range is out of range: %d-%d",
+                                sra->ranges[i].start_slot, sra->ranges[i].end_slot);
+            return C_ERR;
+        }
+
+        if (sra->ranges[i].start_slot > sra->ranges[i].end_slot) {
+            *err = sdscatprintf(sdsempty(), "start slot number %d is greater than end slot number %d",
+                                sra->ranges[i].start_slot, sra->ranges[i].end_slot);
+            return C_ERR;
+        }
+
+        for (int j = sra->ranges[i].start_slot; j <= sra->ranges[i].end_slot; j++) {
+            if (slots[j]) {
+                *err = sdscatprintf(sdsempty(), "Slot %d specified multiple times", j);
+                return C_ERR;
+            }
+            slots[j]++;
+        }
+    }
+    return C_OK;
+}
+
+/* Parse slot ranges from the command arguments. Returns NULL on error. */
+slotRangeArray *parseSlotRangesOrReply(client *c, int argc, int pos) {
+    int start_slot, end_slot, count;
+    slotRangeArray *sra;
+
+    serverAssert(pos <= argc);
+    count = (argc - pos) / 2;
+    sra = zcalloc(sizeof(*sra) + count * sizeof(slotRange));
+
+    for (int j = pos; j < argc; j += 2) {
+        if ((start_slot = getSlotOrReply(c, c->argv[j])) == -1 ||
+            (end_slot = getSlotOrReply(c, c->argv[j + 1])) == -1)
+        {
+            zfree(sra);
+            return NULL;
+        }
+        sra->ranges[sra->num_ranges].start_slot = start_slot;
+        sra->ranges[sra->num_ranges].end_slot = end_slot;
+        sra->num_ranges++;
+    }
+
+    sds err = NULL;
+    if (validateSlotRanges(sra, &err) != C_OK) {
+        addReplyErrorSds(c, err);
+        zfree(sra);
+        return NULL;
+    }
+    return sra;
 }
 
 /* Partially flush destination DB in a cluster node, based on the slot range.
@@ -1618,45 +1678,27 @@ void sflushCommand(client *c) {
         return;
     }
 
-    /* Verify <first, last> slot pairs are valid and not overlapping */
-    long long j, first, last;
+    slotRangeArray *slot_ranges = parseSlotRangesOrReply(c, argc, 1);
+    if (!slot_ranges) return;
+
+    /* Mark the slots in slotsToFlushRq[] */
     unsigned char slotsToFlushRq[CLUSTER_SLOTS] = {0};
-    for (j = 1; j < argc; j += 2) {
-        /* check if the first slot is valid */
-        if (getLongLongFromObject(c->argv[j], &first) != C_OK || first < 0 || first >= CLUSTER_SLOTS) {
-            addReplyError(c,"Invalid or out of range slot");
-            return;
-        }
 
-        /* check if the last slot is valid */
-        if (getLongLongFromObject(c->argv[j+1], &last) != C_OK || last < 0 || last >= CLUSTER_SLOTS) {
-            addReplyError(c,"Invalid or out of range slot");
-            return;
-        }
-
-        if (first > last) {
-            addReplyErrorFormat(c,"start slot number %lld is greater than end slot number %lld", first, last);
-            return;
-        }
-
-        /* Mark the slots in slotsToFlushRq[] */
-        for (int i = first; i <= last; i++) {
-            if (slotsToFlushRq[i]) {
-                addReplyErrorFormat(c, "Slot %d specified multiple times", i);
-                return;
-            }
-            slotsToFlushRq[i] = 1;
-        }
+    for (int i = 0; i < slot_ranges->num_ranges; i++) {
+        slotRange *sr = &slot_ranges->ranges[i];
+        for (int j = sr->start_slot; j <= sr->end_slot; j++)
+            slotsToFlushRq[j] = 1;
     }
+    zfree(slot_ranges);
 
     /* Verify slotsToFlushRq[] covers ALL slots of myNode. */
     clusterNode *myNode = getMyClusterNode();
     /* During iteration trace also the slot range pairs and save in SlotsFlush.
-     * It is allocated on heap since there is a chance that FLUSH SYNC will be 
+     * It is allocated on heap since there is a chance that FLUSH SYNC will be
      * running as blocking ASYNC and only later reply with slot ranges */
     int capacity = 32; /* Initial capacity */
-    SlotsFlush *sflush = zmalloc(sizeof(SlotsFlush) + sizeof(SlotRange) * capacity);
-    sflush->numRanges = 0;
+    slotRangeArray *sflush = zmalloc(sizeof(*sflush) + sizeof(slotRange) * capacity);
+    sflush->num_ranges = 0;
     int inSlotRange = 0;
     for (int i = 0; i < CLUSTER_SLOTS; i++) {
         if (myNode == getNodeBySlot(i)) {
@@ -1667,25 +1709,25 @@ void sflushCommand(client *c) {
             }
 
             if (!inSlotRange) { /* If start another slot range */
-                sflush->ranges[sflush->numRanges].first = i;
+                sflush->ranges[sflush->num_ranges].start_slot = i;
                 inSlotRange = 1;
             }
         } else {
             if (inSlotRange) { /* If end another slot range */
-                sflush->ranges[sflush->numRanges++].last = i - 1;
+                sflush->ranges[sflush->num_ranges++].end_slot = i - 1;
                 inSlotRange = 0;
                 /* If reached 'sflush' capacity, double the capacity */
-                if (sflush->numRanges >= capacity) {
+                if (sflush->num_ranges >= capacity) {
                     capacity *= 2;
-                    sflush = zrealloc(sflush, sizeof(SlotsFlush) + sizeof(SlotRange) * capacity);
+                    sflush = zrealloc(sflush, sizeof(*sflush) + sizeof(slotRange) * capacity);
                 }
             }
         }
     }
 
     /* Update last pair if last cluster slot is also end of last range */
-    if (inSlotRange) sflush->ranges[sflush->numRanges++].last = CLUSTER_SLOTS - 1;
-    
+    if (inSlotRange) sflush->ranges[sflush->num_ranges++].end_slot = CLUSTER_SLOTS - 1;
+
     /* Flush selected slots. If not flush as blocking async, then reply immediately */
     if (flushCommandCommon(c, FLUSH_TYPE_SLOTS, flags, sflush) == 0)
         replySlotsFlushAndFree(c, sflush);

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1621,6 +1621,7 @@ slotRangeArray *parseSlotRangesOrReply(client *c, int argc, int pos) {
 
     count = (argc - pos) / 2;
     sra = zcalloc(sizeof(*sra) + count * sizeof(slotRange));
+    sra->num_ranges = 0;
 
     for (int j = pos; j < argc; j += 2) {
         if ((start = getSlotOrReply(c, c->argv[j])) == -1 ||

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -142,6 +142,7 @@ int isValidAuxString(char *s, unsigned int length);
 void migrateCommand(client *c);
 void clusterCommand(client *c);
 ConnectionType *connTypeOfCluster(void);
+slotRangeArray *parseSlotRangesOrReply(client *c, int argc, int pos);
 
 void clusterGenNodesSlotsInfo(int filter);
 void clusterFreeNodesSlotsInfo(clusterNode *n);

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -17,7 +17,7 @@
 
 typedef struct asmTask {
     int operation;                      /* Either ASM_IMPORT or ASM_MIGRATE */
-    list *slot_ranges;                  /* List of slot ranges for this migration operation */
+    slotRangeArray *slot_ranges;        /* List of slot ranges for this migration operation */
     int state;                          /* Current state of the task */
     char source[CLUSTER_NAMELEN];       /* Source node name */
     char dest[CLUSTER_NAMELEN];         /* Destination node name */
@@ -103,9 +103,9 @@ char *asmTaskStateToString(int state) {
 
 /* Returns C_OK if there is no overlapping import operation in progress for the
  * given slot range. Otherwise, returns C_ERR */
-static int checkOverlappingImport(SlotRange *req) {
-    listIter li, sli;
-    listNode *ln, *sln;
+static int checkOverlappingImport(slotRange *req) {
+    listIter li;
+    listNode *ln;
 
     listRewind(server.cluster->asm_tasks, &li);
     while ((ln = listNext(&li)) != NULL) {
@@ -116,11 +116,10 @@ static int checkOverlappingImport(SlotRange *req) {
             continue;
         }
 
-        listRewind(task->slot_ranges, &sli);
-        while ((sln = listNext(&sli)) != NULL) {
-            SlotRange *sr = sln->value;
+        for (int i = 0; i < task->slot_ranges->num_ranges; i++) {
+            slotRange *sr = &task->slot_ranges->ranges[i];
             /* Cancel if any slot range overlaps with the requested range. */
-            if (sr->first <= req->last && sr->last >= req->first)
+            if (sr->start_slot <= req->end_slot && sr->end_slot >= req->start_slot)
                 return C_ERR;
         }
     }
@@ -137,9 +136,7 @@ static int checkOverlappingImport(SlotRange *req) {
  *
  * Returns the source node if validation succeeds.
  * Otherwise, returns NULL and sets 'err' variable. */
-static clusterNode *validateImportSlotRanges(list *slot_ranges, sds *err) {
-    listNode *ln;
-    listIter li;
+static clusterNode *validateImportSlotRanges(slotRangeArray *slot_ranges, sds *err) {
     clusterNode *source = NULL;
     unsigned char *slots = zcalloc(CLUSTER_SLOTS);
 
@@ -161,41 +158,28 @@ static clusterNode *validateImportSlotRanges(list *slot_ranges, sds *err) {
         }
     }
 
-    listRewind(slot_ranges, &li);
-    while ((ln = listNext(&li))) {
-        SlotRange *sr = listNodeValue(ln);
-
-        /* Validate slot boundaries */
-        if (sr->first > sr->last) {
-            *err = sdscatprintf(sdsempty(), "invalid slot range: %d-%d",
-                                sr->first, sr->last);
-            goto out;
-        }
+    for (int i = 0; i < slot_ranges->num_ranges; i++) {
+        slotRange *sr = &slot_ranges->ranges[i];
 
         /* Ensure no import operation overlaps with this slot range. */
         if (checkOverlappingImport(sr) != C_OK) {
             *err = sdscatprintf(sdsempty(),
                                 "overlapping import exists for slot range: %d-%d",
-                                sr->first, sr->last);
+                                sr->start_slot, sr->end_slot);
             goto out;
         }
 
         /* Validate if we can start migration operation for this slot range. */
-        for (int i = sr->first; i <= sr->last; i++) {
-            if (server.cluster->slots[i] == NULL) {
-                *err = sdscatprintf(sdsempty(), "slot has no owner: %d", i);
+        for (int j = sr->start_slot; j <= sr->end_slot; j++) {
+            if (server.cluster->slots[j] == NULL) {
+                *err = sdscatprintf(sdsempty(), "slot has no owner: %d", j);
                 goto out;
             }
 
             if (!source) {
-                source = server.cluster->slots[i];
-            } else if (source != server.cluster->slots[i]) {
+                source = server.cluster->slots[j];
+            } else if (source != server.cluster->slots[j]) {
                 *err = sdsnew("slots belong to different source nodes");
-                goto out;
-            }
-
-            if (slots[i]++ != 0) {
-                *err = sdscatprintf(sdsempty(), "slot %d is given twice in different slot ranges", i);
                 goto out;
             }
         }
@@ -217,23 +201,10 @@ static void clusterCommandMigrationImport(client *c) {
         return;
     }
 
-    /* Parse slot ranges */
-    int first, last;
-    list *slot_ranges = listCreate();
-    listSetFreeMethod(slot_ranges, zfree);
-
-    for (int i = 3; i < c->argc; i += 2) {
-        if ((first = getSlotOrReply(c, c->argv[i])) == -1 ||
-            (last = getSlotOrReply(c, c->argv[i + 1])) == -1)
-        {
-            listRelease(slot_ranges);
-            return;
-        }
-
-        SlotRange *sr = zmalloc(sizeof(*sr));
-        sr->first = first;
-        sr->last = last;
-        listAddNodeTail(slot_ranges, sr);
+    slotRangeArray *slot_ranges = parseSlotRangesOrReply(c, c->argc, 3);
+    if (!slot_ranges) {
+        zfree(slot_ranges);
+        return;
     }
 
     sds err = NULL;
@@ -244,13 +215,13 @@ static void clusterCommandMigrationImport(client *c) {
     source = validateImportSlotRanges(slot_ranges, &err);
     if (!source) {
         addReplyErrorSds(c, err);
-        listRelease(slot_ranges);
+        zfree(slot_ranges);
         return;
     }
 
     if (source == getMyClusterNode()) {
         addReplyError(c, "this node is already the owner of the slot range");
-        listRelease(slot_ranges);
+        zfree(slot_ranges);
         return;
     }
 
@@ -276,10 +247,10 @@ static void clusterCommandMigrationImport(client *c) {
 
 /* Cancel atomic slot migration operations that overlap with the given slot
  * range. Returns the number of cancelled operations. */
-static int cancelLinksForSlotRange(SlotRange *req_range) {
+static int cancelLinksForSlotRange(slotRange *req_range) {
     int num_cancelled = 0;
-    listIter li, sli;
-    listNode *ln, *sln;
+    listIter li;
+    listNode *ln;
 
     listRewind(server.cluster->asm_tasks, &li);
     while ((ln = listNext(&li)) != NULL) {
@@ -290,11 +261,12 @@ static int cancelLinksForSlotRange(SlotRange *req_range) {
             continue;
         }
 
-        listRewind(task->slot_ranges, &sli);
-        while ((sln = listNext(&sli)) != NULL) {
-            SlotRange *sr = sln->value;
+        for (int i = 0; i < task->slot_ranges->num_ranges; i++) {
+            slotRange *sr = &task->slot_ranges->ranges[i];
             /* Cancel if any slot range overlaps with the requested range. */
-            if (sr->first <= req_range->last && sr->last >= req_range->first) {
+            if (sr->start_slot <= req_range->end_slot &&
+                sr->end_slot >= req_range->start_slot)
+            {
                 task->state = ASM_CANCELED;
                 num_cancelled++;
                 break;
@@ -310,7 +282,7 @@ static int cancelLinksForSlotRange(SlotRange *req_range) {
  * Cancels import operations that overlap with the specified slot ranges.
  * Multiple operations may be cancelled. */
 static void clusterCommandMigrationCancel(client *c) {
-    int remaining, first, last;
+    int remaining, start_slot, end_slot;
     int num_cancelled = 0;
     listIter li;
     listNode *ln;
@@ -328,22 +300,23 @@ static void clusterCommandMigrationCancel(client *c) {
 
     /* Parse slot ranges into the list */
     for (int i = 3; i < c->argc; i += 2) {
-        if ((first = getSlotOrReply(c, c->argv[i])) == -1 ||
-            (last = getSlotOrReply(c, c->argv[i + 1])) == -1)
+        if ((start_slot = getSlotOrReply(c, c->argv[i])) == -1 ||
+            (end_slot = getSlotOrReply(c, c->argv[i + 1])) == -1)
         {
             listRelease(slot_ranges);
             return;
         }
 
-        if (first > last) {
-            addReplyErrorFormat(c, "invalid slot range: %d-%d", first, last);
+        if (start_slot > end_slot) {
+            addReplyErrorFormat(c, "invalid slot range: %d-%d",
+                                start_slot, end_slot);
             listRelease(slot_ranges);
             return;
         }
 
-        SlotRange *sr = zmalloc(sizeof(*sr));
-        sr->first = first;
-        sr->last = last;
+        slotRange *sr = zmalloc(sizeof(*sr));
+        sr->start_slot = start_slot;
+        sr->end_slot = end_slot;
         listAddNodeTail(slot_ranges, sr);
     }
 
@@ -358,15 +331,12 @@ static void clusterCommandMigrationCancel(client *c) {
 }
 
 /* Create a slot range string in the format of: "1000-2000 3000-4000 ..." */
-static sds createSlotRangesStr(list *slot_ranges) {
-    listNode *ln;
-    listIter li;
+static sds createSlotRangesStr(slotRangeArray *slot_ranges) {
     sds s = sdsempty();
 
-    listRewind(slot_ranges, &li);
-    while ((ln = listNext(&li)) != NULL) {
-        SlotRange *range = listNodeValue(ln);
-        s = sdscatprintf(s, "%d-%d ", range->first, range->last);
+    for (int i = 0; i < slot_ranges->num_ranges; i++) {
+        slotRange *sr = &slot_ranges->ranges[i];
+        s = sdscatprintf(s, "%d-%d ", sr->start_slot, sr->end_slot);
     }
     sdssetlen(s, sdslen(s) - 1);
     s[sdslen(s)] = '\0';
@@ -560,7 +530,7 @@ void asmSyncWithSource(connection *conn) {
 
     if (task->state == ASM_SEND_SYNCSLOTS) {
         /* Prepare and send CLUSTER SYNCSLOTS RANGES command */
-        size_t argc = (listLength(task->slot_ranges)*2 + 3);
+        size_t argc = (task->slot_ranges->num_ranges*2 + 3);
         char **args = zcalloc(sizeof(char*) * argc);
         size_t *lens = zcalloc(sizeof(size_t) * argc);
         args[0] = "CLUSTER";
@@ -571,14 +541,11 @@ void asmSyncWithSource(connection *conn) {
         lens[2] = strlen("RANGES");
 
         size_t i = 3;
-        listNode *ln;
-        listIter li;
-        listRewind(task->slot_ranges, &li);
-        while ((ln = listNext(&li)) != NULL) {
-            SlotRange *sr = listNodeValue(ln);
-            args[i] = sdscatprintf(sdsempty(), "%d", sr->first);
+        for (int j = 0; j < task->slot_ranges->num_ranges; j++) {
+            slotRange *sr = &task->slot_ranges->ranges[j];
+            args[i] = sdscatprintf(sdsempty(), "%d", sr->start_slot);
             lens[i] = sdslen(args[i]);
-            args[i+1] = sdscatprintf(sdsempty(), "%d", sr->last);
+            args[i+1] = sdscatprintf(sdsempty(), "%d", sr->end_slot);
             lens[i+1] = sdslen(args[i+1]);
             i += 2;
         }
@@ -713,15 +680,13 @@ void clusterSyncSlotsStreamEOF(client *c) {
     
     /* Iterate task->slot_range, and handoff the ownership of slots */
     task->state = ASM_SLOTS_HANDOFF;
-    listIter li;
-    listNode *ln;
-    listRewind(task->slot_ranges, &li);
-    while ((ln = listNext(&li)) != NULL) {
-        SlotRange *sr = listNodeValue(ln);
-        for (int i = sr->first; i <= sr->last; i++) {
+
+    for (int i = 0; i < task->slot_ranges->num_ranges; i++) {
+        slotRange *sr = &task->slot_ranges->ranges[i];
+        for (int j = sr->start_slot; j <= sr->end_slot; j++) {
             clusterNode *myself = getMyClusterNode();
-            server.cluster->slots[i] = myself;
-            clusterNodeSetSlotBit(myself, i);
+            server.cluster->slots[j] = myself;
+            clusterNodeSetSlotBit(myself, j);
         }
     }
     /* New config and Bump new config */
@@ -736,7 +701,7 @@ void clusterSyncSlotsStreamEOF(client *c) {
 
     /* Free the task */
     listDelNode(server.cluster->asm_tasks, listSearchKey(server.cluster->asm_tasks, task));
-    listRelease(task->slot_ranges); /* Free the slot ranges list */
+    zfree(task->slot_ranges); /* Free the slot ranges list */
     zfree(task); /* Free the task itself */
     serverLog(LL_NOTICE, "Slot migration task completed");
 
@@ -767,28 +732,13 @@ void asmStartSyncSlots(asmTask *task) {
 void clusterSyncSlotsCommand(client *c) {
     if (!strcasecmp(c->argv[2]->ptr, "ranges") && c->argc >= 5) {
         /* CLUSTER SYNCSLOTS RANGES <start-slot> <end-slot> [<start-slot> <end-slot>] */
-        int j, first, last;
         if (c->argc % 2 == 0) {
             addReplyErrorArity(c);
             return;
         }
 
-        list *slot_ranges = listCreate();
-        listSetFreeMethod(slot_ranges, zfree);
-
-        for (j = 3; j < c->argc; j += 2) {
-            if ((first = getSlotOrReply(c, c->argv[j])) == -1 ||
-                (last = getSlotOrReply(c, c->argv[j + 1])) == -1) 
-            {
-                listRelease(slot_ranges);
-                return;
-            }
-
-            SlotRange *sr = zmalloc(sizeof(*sr));
-            sr->first = first;
-            sr->last = last;
-            listAddNodeTail(slot_ranges, sr);
-        }
+        slotRangeArray *slot_ranges = parseSlotRangesOrReply(c, c->argc, 3);
+        if (!slot_ranges) return;
 
         /* Validate that the slot ranges are valid and that migration can be
          * initiated for them. */
@@ -796,21 +746,21 @@ void clusterSyncSlotsCommand(client *c) {
         clusterNode *source = validateImportSlotRanges(slot_ranges, &err);
         if (!source) {
             addReplyErrorSds(c, err);
-            listRelease(slot_ranges);
+            zfree(slot_ranges);
             return;
         }
 
         /* Check if the source node is the same as the current node. */
         if (source != getMyClusterNode()) {
             addReplyError(c, "This node is not the owner of the slots");
-            listRelease(slot_ranges);
+            zfree(slot_ranges);
             return;
         }
 
         /* Only one slots sync on source node */
         if (listLength(server.cluster->asm_tasks) != 0) {
             addReplyError(c, "SYNCSLOTS RANGES already in progress");
-            listRelease(slot_ranges);
+            zfree(slot_ranges);
             return;
         }
 
@@ -914,7 +864,7 @@ void clusterSyncSlotsCommand(client *c) {
         sendCommand(c->conn, "CLUSTER", "SYNCSLOTS", "STREAM-EOF", NULL);
 
         listDelNode(server.cluster->asm_tasks, listFirst(server.cluster->asm_tasks));
-        listRelease(task->slot_ranges); /* Free the slot ranges list */
+        zfree(task->slot_ranges); /* Free the slot ranges list */
         zfree(task); /* Free the task itself */
         freeClientAsync(c); /* Free the client, it is no longer needed. */
     } else if (!strcasecmp(c->argv[2]->ptr, "fail") && c->argc == 4) {
@@ -972,14 +922,11 @@ int slotRangesSnapshotSaveRio(int req, rio *rdb, int *error) {
 
         /* Iterate all slot ranges, and generate the DUMP encoded
          * representation of each key in the DB. */
-        listIter li;
-        listNode *ln;
-        listRewind(task->slot_ranges, &li);
-        while ((ln = listNext(&li)) != NULL) {
-            SlotRange *sr = listNodeValue(ln);
+        for (int i = 0; i < task->slot_ranges->num_ranges; i++) {
+            slotRange *sr = &task->slot_ranges->ranges[i];
             /* Iterate all keys in the slot range */
-            for (int i = sr->first; i <= sr->last; i++) {
-                kvs_di = kvstoreGetDictIterator(server.db->keys, i);
+            for (int j = sr->start_slot; j <= sr->end_slot; j++) {
+                kvs_di = kvstoreGetDictIterator(server.db->keys, j);
                 while ((de = kvstoreDictIteratorNext(kvs_di)) != NULL) {
                     /* Get the value object (of type kvobj) */
                     kvobj *o = dictGetKV(de);

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -119,7 +119,7 @@ static int checkOverlappingImport(slotRange *req) {
         for (int i = 0; i < task->slot_ranges->num_ranges; i++) {
             slotRange *sr = &task->slot_ranges->ranges[i];
             /* Cancel if any slot range overlaps with the requested range. */
-            if (sr->start_slot <= req->end_slot && sr->end_slot >= req->start_slot)
+            if (sr->start <= req->end && sr->end >= req->start)
                 return C_ERR;
         }
     }
@@ -165,12 +165,12 @@ static clusterNode *validateImportSlotRanges(slotRangeArray *slot_ranges, sds *e
         if (checkOverlappingImport(sr) != C_OK) {
             *err = sdscatprintf(sdsempty(),
                                 "overlapping import exists for slot range: %d-%d",
-                                sr->start_slot, sr->end_slot);
+                                sr->start, sr->end);
             goto out;
         }
 
         /* Validate if we can start migration operation for this slot range. */
-        for (int j = sr->start_slot; j <= sr->end_slot; j++) {
+        for (int j = sr->start; j <= sr->end; j++) {
             if (server.cluster->slots[j] == NULL) {
                 *err = sdscatprintf(sdsempty(), "slot has no owner: %d", j);
                 goto out;
@@ -202,10 +202,7 @@ static void clusterCommandMigrationImport(client *c) {
     }
 
     slotRangeArray *slot_ranges = parseSlotRangesOrReply(c, c->argc, 3);
-    if (!slot_ranges) {
-        zfree(slot_ranges);
-        return;
-    }
+    if (!slot_ranges) return;
 
     sds err = NULL;
     clusterNode *source;
@@ -264,9 +261,7 @@ static int cancelLinksForSlotRange(slotRange *req_range) {
         for (int i = 0; i < task->slot_ranges->num_ranges; i++) {
             slotRange *sr = &task->slot_ranges->ranges[i];
             /* Cancel if any slot range overlaps with the requested range. */
-            if (sr->start_slot <= req_range->end_slot &&
-                sr->end_slot >= req_range->start_slot)
-            {
+            if (sr->start <= req_range->end && sr->end >= req_range->start) {
                 task->state = ASM_CANCELED;
                 num_cancelled++;
                 break;
@@ -282,11 +277,8 @@ static int cancelLinksForSlotRange(slotRange *req_range) {
  * Cancels import operations that overlap with the specified slot ranges.
  * Multiple operations may be cancelled. */
 static void clusterCommandMigrationCancel(client *c) {
-    int remaining, start_slot, end_slot;
-    int num_cancelled = 0;
-    listIter li;
-    listNode *ln;
-    list *slot_ranges;
+    int remaining, num_cancelled = 0;
+    slotRangeArray *slot_ranges;
 
     /* Validate slot range arg count */
     remaining = c->argc - 3;
@@ -295,39 +287,15 @@ static void clusterCommandMigrationCancel(client *c) {
         return;
     }
 
-    slot_ranges = listCreate();
-    listSetFreeMethod(slot_ranges, zfree);
-
-    /* Parse slot ranges into the list */
-    for (int i = 3; i < c->argc; i += 2) {
-        if ((start_slot = getSlotOrReply(c, c->argv[i])) == -1 ||
-            (end_slot = getSlotOrReply(c, c->argv[i + 1])) == -1)
-        {
-            listRelease(slot_ranges);
-            return;
-        }
-
-        if (start_slot > end_slot) {
-            addReplyErrorFormat(c, "invalid slot range: %d-%d",
-                                start_slot, end_slot);
-            listRelease(slot_ranges);
-            return;
-        }
-
-        slotRange *sr = zmalloc(sizeof(*sr));
-        sr->start_slot = start_slot;
-        sr->end_slot = end_slot;
-        listAddNodeTail(slot_ranges, sr);
-    }
+    slot_ranges = parseSlotRangesOrReply(c, c->argc, 3);
+    if (!slot_ranges) return;
 
     /* Cancel asm operations that overlaps with the slot ranges. */
-    listRewind(slot_ranges, &li);
-    while ((ln = listNext(&li)) != NULL) {
-        num_cancelled += cancelLinksForSlotRange(listNodeValue(ln));
-    }
+    for (int i = 0; i < slot_ranges->num_ranges; i++)
+        num_cancelled += cancelLinksForSlotRange(&slot_ranges->ranges[i]);
 
     addReplyLongLong(c, num_cancelled);
-    listRelease(slot_ranges);
+    zfree(slot_ranges);
 }
 
 /* Create a slot range string in the format of: "1000-2000 3000-4000 ..." */
@@ -336,7 +304,7 @@ static sds createSlotRangesStr(slotRangeArray *slot_ranges) {
 
     for (int i = 0; i < slot_ranges->num_ranges; i++) {
         slotRange *sr = &slot_ranges->ranges[i];
-        s = sdscatprintf(s, "%d-%d ", sr->start_slot, sr->end_slot);
+        s = sdscatprintf(s, "%d-%d ", sr->start, sr->end);
     }
     sdssetlen(s, sdslen(s) - 1);
     s[sdslen(s)] = '\0';
@@ -543,9 +511,9 @@ void asmSyncWithSource(connection *conn) {
         size_t i = 3;
         for (int j = 0; j < task->slot_ranges->num_ranges; j++) {
             slotRange *sr = &task->slot_ranges->ranges[j];
-            args[i] = sdscatprintf(sdsempty(), "%d", sr->start_slot);
+            args[i] = sdscatprintf(sdsempty(), "%d", sr->start);
             lens[i] = sdslen(args[i]);
-            args[i+1] = sdscatprintf(sdsempty(), "%d", sr->end_slot);
+            args[i+1] = sdscatprintf(sdsempty(), "%d", sr->end);
             lens[i+1] = sdslen(args[i+1]);
             i += 2;
         }
@@ -683,7 +651,7 @@ void clusterSyncSlotsStreamEOF(client *c) {
 
     for (int i = 0; i < task->slot_ranges->num_ranges; i++) {
         slotRange *sr = &task->slot_ranges->ranges[i];
-        for (int j = sr->start_slot; j <= sr->end_slot; j++) {
+        for (int j = sr->start; j <= sr->end; j++) {
             clusterNode *myself = getMyClusterNode();
             server.cluster->slots[j] = myself;
             clusterNodeSetSlotBit(myself, j);
@@ -925,7 +893,7 @@ int slotRangesSnapshotSaveRio(int req, rio *rdb, int *error) {
         for (int i = 0; i < task->slot_ranges->num_ranges; i++) {
             slotRange *sr = &task->slot_ranges->ranges[i];
             /* Iterate all keys in the slot range */
-            for (int j = sr->start_slot; j <= sr->end_slot; j++) {
+            for (int j = sr->start; j <= sr->end; j++) {
                 kvs_di = kvstoreGetDictIterator(server.db->keys, j);
                 while ((de = kvstoreDictIteratorNext(kvs_di)) != NULL) {
                     /* Get the value object (of type kvobj) */

--- a/src/db.c
+++ b/src/db.c
@@ -977,7 +977,7 @@ void flushAllDataAndResetRDB(int flags) {
  * Utilized by commands SFLUSH, FLUSHALL and FLUSHDB.
  */
 void flushallSyncBgDone(uint64_t client_id, void *sflush) {
-    SlotsFlush *slotsFlush = sflush;
+    slotRangeArray *slotsFlush = sflush;
     client *c = lookupClientByID(client_id);
 
     /* Verify that client still exists and being blocked. */
@@ -1026,7 +1026,7 @@ void flushallSyncBgDone(uint64_t client_id, void *sflush) {
  *          completion to reply with the slots flush result. Ownership is passed
  *          to the completion job in case of `blocking_async`.
  */
-int flushCommandCommon(client *c, int type, int flags, SlotsFlush *sflush) {
+int flushCommandCommon(client *c, int type, int flags, slotRangeArray *sflush) {
     int blocking_async = 0; /* Flush SYNC option to run as blocking ASYNC */
 
     /* in case of SYNC, check if we can optimize and run it in bg as blocking ASYNC */

--- a/src/server.h
+++ b/src/server.h
@@ -3657,7 +3657,7 @@ kvobj *dbUnshareStringValueByLink(redisDb *db, robj *key, kvobj *kv, dictEntryLi
 #define FLUSH_TYPE_DB    1
 #define FLUSH_TYPE_SLOTS 2
 typedef struct slotRange {
-    unsigned short start_slot, end_slot;
+    unsigned short start, end;
 } slotRange;
 typedef struct slotRangeArray {
     int num_ranges;

--- a/src/server.h
+++ b/src/server.h
@@ -3656,15 +3656,15 @@ kvobj *dbUnshareStringValueByLink(redisDb *db, robj *key, kvobj *kv, dictEntryLi
 #define FLUSH_TYPE_ALL   0
 #define FLUSH_TYPE_DB    1
 #define FLUSH_TYPE_SLOTS 2
-typedef struct SlotRange {
-    unsigned short first, last;
-} SlotRange;
-typedef struct SlotsFlush {
-    int numRanges;
-    SlotRange ranges[];
-} SlotsFlush;
-void replySlotsFlushAndFree(client *c, SlotsFlush *sflush);
-int flushCommandCommon(client *c, int type, int flags, SlotsFlush *sflush);
+typedef struct slotRange {
+    unsigned short start_slot, end_slot;
+} slotRange;
+typedef struct slotRangeArray {
+    int num_ranges;
+    slotRange ranges[];
+} slotRangeArray;
+void replySlotsFlushAndFree(client *c, slotRangeArray *ranges);
+int flushCommandCommon(client *c, int type, int flags, slotRangeArray *ranges);
 #define EMPTYDB_NO_FLAGS 0      /* No flags. */
 #define EMPTYDB_ASYNC (1<<0)    /* Reclaim memory in another thread. */
 #define EMPTYDB_NOFUNCTIONS (1<<1) /* Indicate not to flush the functions. */

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -4,7 +4,7 @@ start_cluster 3 3 {tags {external:skip cluster}} {
         assert_error {*wrong number of arguments*} {R 0 CLUSTER MIGRATION IMPORT}
         assert_error {*wrong number of arguments*} {R 0 CLUSTER MIGRATION IMPORT 100}
         assert_error {*wrong number of arguments*} {R 0 CLUSTER MIGRATION IMPORT 100 200 300}
-        assert_error {*invalid slot range*} {R 0 CLUSTER MIGRATION IMPORT 200 100}
+        assert_error {*greater than end slot number*} {R 0 CLUSTER MIGRATION IMPORT 200 100}
         assert_error {*out of range slot*} {R 0 CLUSTER MIGRATION IMPORT 17000 18000}
         assert_error {*out of range slot*} {R 0 CLUSTER MIGRATION IMPORT 14000 18000}
         assert_error {*out of range slot*} {R 0 CLUSTER MIGRATION IMPORT -1 0}
@@ -53,8 +53,8 @@ start_cluster 3 3 {tags {external:skip cluster}} {
     }
 
     test "Test IMPORT not allowed if slot is given multiple times" {
-        assert_error {*slot*is given twice in different slot ranges*} {R 0 CLUSTER MIGRATION IMPORT 7000 8000 8000 9000}
-        assert_error {*slot*is given twice in different slot ranges*} {R 0 CLUSTER MIGRATION IMPORT 7000 8000 7900 9000}
+        assert_error {*Slot*specified multiple times*} {R 0 CLUSTER MIGRATION IMPORT 7000 8000 8000 9000}
+        assert_error {*Slot*specified multiple times*} {R 0 CLUSTER MIGRATION IMPORT 7000 8000 7900 9000}
     }
 
     test "Test IMPORT not allowed if there is an overlapping import" {


### PR DESCRIPTION
I did refactor a few things. 

- First used `struct slotRangeArray` instead of `list *slot_ranges`. For plugin API, I see that we need to work with primitive types as the current plugin will be in rust, it is harder to use `list` like complex structs there.  `struct slotRangeArray` is easier to translate to other languages. Also, I see `list *slot_ranges` does not have much benefit over an array of slot ranges. 
- To prevent terminology mixup, I refactored `struct slotRange` and used `start_slot/end_slot` instead of `first/last`. 
- Tried to reuse parser code for `sflush`, `cluster import` and `cluster syncslots`