### PR TITLE
Add partial flush support to SFLUSH command

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1616,9 +1616,9 @@ unsigned int clusterDelKeysInSlot(unsigned int hashslot, int flags) {
     return j;
 }
 
+/* Delete the keys in the slot ranges. Returns the number of deleted items */
 unsigned int clusterDelKeysInSlotRangeArray(slotRangeArray *sra, int flags) {
     unsigned int j = 0;
-
     for (int i = 0; i < sra->num_ranges; i++) {
         for (int slot = sra->ranges[i].start; slot <= sra->ranges[i].end; slot++) {
             j += clusterDelKeysInSlot(slot, flags);

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1572,6 +1572,61 @@ void readonlyCommand(client *c) {
     addReply(c,shared.ok);
 }
 
+/* Remove all the keys in the specified hash slot.
+ * The number of removed items is returned. */
+unsigned int clusterDelKeysInSlot(unsigned int hashslot, int flags) {
+    unsigned int j = 0;
+
+    if (!kvstoreDictSize(server.db->keys, (int) hashslot))
+        return 0;
+
+    kvstoreDictIterator *kvs_di = NULL;
+    dictEntry *de = NULL;
+    kvs_di = kvstoreGetDictSafeIterator(server.db->keys, (int) hashslot);
+    while((de = kvstoreDictIteratorNext(kvs_di)) != NULL) {
+        enterExecutionUnit(1, 0);
+        sds sdskey = kvobjGetKey(dictGetKV(de));
+        robj *key = createStringObject(sdskey, sdslen(sdskey));
+
+        if (flags & CLUSTER_DELKEYS_ASYNC) dbAsyncDelete(&server.db[0], key);
+        else dbSyncDelete(&server.db[0], key);
+
+        signalModifiedKey(NULL, &server.db[0], key);
+        if (flags & CLUSTER_DELKEYS_BY_COMMAND) {
+            /* Keys are not migrated but actually deleted. Command (sflush)
+             * will be propagated, so there is no need to propagate each
+             * deletion of the key. */
+            notifyKeyspaceEvent(NOTIFY_GENERIC, "del", key, server.db[0].id);
+        } else {
+            /* Propagate the DEL command */
+            propagateDeletion(&server.db[0], key, server.lazyfree_lazy_server_del);
+            /* The keys are not actually logically deleted from the database,
+             * just moved to another node. The modules needs to know that these
+             * keys are no longer available locally, so just send the keyspace
+             * notification to the modules, but not to clients. */
+            moduleNotifyKeyspaceEvent(NOTIFY_GENERIC, "del", key, server.db[0].id);
+        }
+        exitExecutionUnit();
+        postExecutionUnitOperations();
+        decrRefCount(key);
+        j++;
+        server.dirty++;
+    }
+    kvstoreReleaseDictIterator(kvs_di);
+    return j;
+}
+
+unsigned int clusterDelKeysInSlotRangeArray(slotRangeArray *sra, int flags) {
+    unsigned int j = 0;
+
+    for (int i = 0; i < sra->num_ranges; i++) {
+        for (int slot = sra->ranges[i].start; slot <= sra->ranges[i].end; slot++) {
+            j += clusterDelKeysInSlot(slot, flags);
+        }
+    }
+    return j;
+}
+
 void replySlotsFlushAndFree(client *c, slotRangeArray *sra) {
     addReplyArrayLen(c, sra->num_ranges);
     for (int i = 0 ; i < sra->num_ranges ; i++) {
@@ -1682,59 +1737,54 @@ void sflushCommand(client *c) {
         return;
     }
 
+    /* Parse slot ranges from the command arguments. */
     slotRangeArray *slot_ranges = parseSlotRangesOrReply(c, argc, 1);
     if (!slot_ranges) return;
 
-    /* Mark the slots in slotsToFlushRq[] */
-    unsigned char slotsToFlushRq[CLUSTER_SLOTS] = {0};
+    /* Iterate and find the slot ranges that belong to this node. Save them in
+     * a new slotRangeArray. It is allocated on heap since there is a chance
+     * that FLUSH SYNC will be running as blocking ASYNC and only later reply
+     * with slot ranges */
+    int in_slot_range = 0;
+    int capacity = 32; /* Initial capacity */
+
+    slotRangeArray *myslots = zmalloc(sizeof(*myslots) + sizeof(slotRange) * capacity);
+    myslots->num_ranges = 0;
 
     for (int i = 0; i < slot_ranges->num_ranges; i++) {
         slotRange *sr = &slot_ranges->ranges[i];
-        for (int j = sr->start; j <= sr->end; j++)
-            slotsToFlushRq[j] = 1;
-    }
-    zfree(slot_ranges);
-
-    /* Verify slotsToFlushRq[] covers ALL slots of myNode. */
-    clusterNode *myNode = getMyClusterNode();
-    /* During iteration trace also the slot range pairs and save in SlotsFlush.
-     * It is allocated on heap since there is a chance that FLUSH SYNC will be
-     * running as blocking ASYNC and only later reply with slot ranges */
-    int capacity = 32; /* Initial capacity */
-    slotRangeArray *sflush = zmalloc(sizeof(*sflush) + sizeof(slotRange) * capacity);
-    sflush->num_ranges = 0;
-    int inSlotRange = 0;
-    for (int i = 0; i < CLUSTER_SLOTS; i++) {
-        if (myNode == getNodeBySlot(i)) {
-            if (!slotsToFlushRq[i]) {
-                addReplySetLen(c, 0); /* Not all slots of mynode got covered. See sflushCommand() comment. */
-                zfree(sflush);
-                return;
+        for (int slot = sr->start; slot <= sr->end; slot++) {
+            if (myslots->num_ranges >= capacity) {
+                capacity *= 2;
+                myslots = zrealloc(myslots, sizeof(*myslots) + sizeof(slotRange) * capacity);
             }
+            /* Check if this slot belongs to this node */
+            int myslot = (getNodeBySlot(slot) == getMyClusterNode());
 
-            if (!inSlotRange) { /* If start another slot range */
-                sflush->ranges[sflush->num_ranges].start = i;
-                inSlotRange = 1;
+            /* Start range on first owned slot, end range on first unowned slot */
+            if (myslot && !in_slot_range) {
+                in_slot_range = 1;
+                myslots->ranges[myslots->num_ranges].start = slot;
+            } else if (!myslot && in_slot_range) {
+                in_slot_range = 0;
+                myslots->ranges[myslots->num_ranges++].end = slot - 1;
             }
-        } else {
-            if (inSlotRange) { /* If end another slot range */
-                sflush->ranges[sflush->num_ranges++].end = i - 1;
-                inSlotRange = 0;
-                /* If reached 'sflush' capacity, double the capacity */
-                if (sflush->num_ranges >= capacity) {
-                    capacity *= 2;
-                    sflush = zrealloc(sflush, sizeof(*sflush) + sizeof(slotRange) * capacity);
-                }
+        }
+        if (in_slot_range) {
+            /* End the current slot range if this is the last range or if
+             * there's a gap before the next range starts. */
+            int last_range = (i == slot_ranges->num_ranges - 1);
+            if (last_range || slot_ranges->ranges[i + 1].start != sr->end + 1) {
+                myslots->ranges[myslots->num_ranges++].end = sr->end;
+                in_slot_range = 0;
             }
         }
     }
-
-    /* Update last pair if last cluster slot is also end of last range */
-    if (inSlotRange) sflush->ranges[sflush->num_ranges++].end = CLUSTER_SLOTS - 1;
+    zfree(slot_ranges);
 
     /* Flush selected slots. If not flush as blocking async, then reply immediately */
-    if (flushCommandCommon(c, FLUSH_TYPE_SLOTS, flags, sflush) == 0)
-        replySlotsFlushAndFree(c, sflush);
+    if (flushCommandCommon(c, FLUSH_TYPE_SLOTS, flags, myslots) == 0)
+        replySlotsFlushAndFree(c, myslots);
 }
 
 /* The READWRITE command just clears the READONLY command state. */

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -147,6 +147,12 @@ sds createSlotRangesStr(slotRangeArray *slot_ranges);
 int validateSlotRanges(slotRangeArray *sra, sds *err);
 slotRangeArray *parseSlotRangesOrReply(client *c, int argc, int pos);
 
+#define CLUSTER_DELKEYS_NONE        (0)
+#define CLUSTER_DELKEYS_ASYNC       (1 << 0)
+#define CLUSTER_DELKEYS_BY_COMMAND  (1 << 1)
+unsigned int clusterDelKeysInSlot(unsigned int hashslot, int flags);
+unsigned int clusterDelKeysInSlotRangeArray(slotRangeArray *sra, int flags);
+
 void clusterGenNodesSlotsInfo(int filter);
 void clusterFreeNodesSlotsInfo(clusterNode *n);
 int clusterNodeSlotInfoCount(clusterNode *n);

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -998,6 +998,11 @@ void clusterSyncSlotsCommand(client *c) {
         if (c->node_id) memcpy(task->dest, c->node_id, CLUSTER_NAMELEN);
         c->task = task;
 
+        clusterNode *dst = clusterLookupNode(task->dest, CLUSTER_NAMELEN);
+        if (dst) {
+            int port = server.tls_replication ? dst->tls_port : dst->tcp_port;
+            c->slave_listening_port = port;
+        }
         /* Add the task to the list of active tasks */
         listAddNodeTail(asmManager->tasks, task);
 

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -76,7 +76,7 @@ const char *clusterGetMessageTypeString(int type);
 void removeChannelsInSlot(unsigned int slot);
 unsigned int countKeysInSlot(unsigned int hashslot);
 unsigned int countChannelsInSlot(unsigned int hashslot);
-unsigned int delKeysInSlot(unsigned int hashslot);
+unsigned int clusterDelKeysInSlot(unsigned int hashslot, int flags);
 void clusterAddNodeToShard(const char *shard_id, clusterNode *node);
 list *clusterLookupNodeListByShardId(const char *shard_id);
 void clusterRemoveNodeFromShard(clusterNode *node);
@@ -2497,7 +2497,7 @@ void clusterUpdateSlotsConfigWith(clusterNode *sender, uint64_t senderConfigEpoc
          * In order to maintain a consistent state between keys and slots
          * we need to remove all the keys from the slots we lost. */
         for (j = 0; j < dirty_slots_count; j++)
-            delKeysInSlot(dirty_slots[j]);
+            clusterDelKeysInSlot(dirty_slots[j], 0);
     }
 }
 
@@ -5823,39 +5823,6 @@ void removeChannelsInSlot(unsigned int slot) {
     if (countChannelsInSlot(slot) == 0) return;
 
     pubsubShardUnsubscribeAllChannelsInSlot(slot);
-}
-
-/* Remove all the keys in the specified hash slot.
- * The number of removed items is returned. */
-unsigned int delKeysInSlot(unsigned int hashslot) {
-    if (!kvstoreDictSize(server.db->keys, hashslot))
-        return 0;
-
-    unsigned int j = 0;
-
-    kvstoreDictIterator *kvs_di = NULL;
-    dictEntry *de = NULL;
-    kvs_di = kvstoreGetDictSafeIterator(server.db->keys, hashslot);
-    while((de = kvstoreDictIteratorNext(kvs_di)) != NULL) {
-        enterExecutionUnit(1, 0);
-        sds sdskey = kvobjGetKey(dictGetKV(de));
-        robj *key = createStringObject(sdskey, sdslen(sdskey));
-        dbDelete(&server.db[0], key);
-        propagateDeletion(&server.db[0], key, server.lazyfree_lazy_server_del);
-        signalModifiedKey(NULL, &server.db[0], key);
-        /* The keys are not actually logically deleted from the database, just moved to another node.
-         * The modules needs to know that these keys are no longer available locally, so just send the
-         * keyspace notification to the modules, but not to clients. */
-        moduleNotifyKeyspaceEvent(NOTIFY_GENERIC, "del", key, server.db[0].id);
-        exitExecutionUnit();
-        postExecutionUnitOperations();
-        decrRefCount(key);
-        j++;
-        server.dirty++;
-    }
-    kvstoreReleaseDictIterator(kvs_di);
-
-    return j;
 }
 
 /* Get the count of the channels for a given slot. */

--- a/src/commands.def
+++ b/src/commands.def
@@ -7930,6 +7930,41 @@ struct COMMAND_ARG RESTORE_ASKING_Args[] = {
 #define SAVE_Keyspecs NULL
 #endif
 
+/********** SFLUSH ********************/
+
+#ifndef SKIP_CMD_HISTORY_TABLE
+/* SFLUSH history */
+#define SFLUSH_History NULL
+#endif
+
+#ifndef SKIP_CMD_TIPS_TABLE
+/* SFLUSH tips */
+#define SFLUSH_Tips NULL
+#endif
+
+#ifndef SKIP_CMD_KEY_SPECS_TABLE
+/* SFLUSH key specs */
+#define SFLUSH_Keyspecs NULL
+#endif
+
+/* SFLUSH data argument table */
+struct COMMAND_ARG SFLUSH_data_Subargs[] = {
+{MAKE_ARG("slot-start",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("slot-last",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+};
+
+/* SFLUSH flush_type argument table */
+struct COMMAND_ARG SFLUSH_flush_type_Subargs[] = {
+{MAKE_ARG("async",ARG_TYPE_PURE_TOKEN,-1,"ASYNC",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("sync",ARG_TYPE_PURE_TOKEN,-1,"SYNC",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+};
+
+/* SFLUSH argument table */
+struct COMMAND_ARG SFLUSH_Args[] = {
+{MAKE_ARG("data",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,2,NULL),.subargs=SFLUSH_data_Subargs},
+{MAKE_ARG("flush-type",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,2,NULL),.subargs=SFLUSH_flush_type_Subargs},
+};
+
 /********** SHUTDOWN ********************/
 
 #ifndef SKIP_CMD_HISTORY_TABLE
@@ -11328,6 +11363,7 @@ struct COMMAND_STRUCT redisCommandTable[] = {
 {MAKE_CMD("restore-asking","An internal command for migrating keys in a cluster.","O(1) to create the new key and additional O(N*M) to reconstruct the serialized value, where N is the number of Redis objects composing the value and M their average size. For small string values the time complexity is thus O(1)+O(1*M) where M is small, so simply O(1). However for sorted set values the complexity is O(N*M*log(N)) because inserting values into sorted sets is O(log(N)).","3.0.0",CMD_DOC_SYSCMD,NULL,NULL,"server",COMMAND_GROUP_SERVER,RESTORE_ASKING_History,3,RESTORE_ASKING_Tips,0,restoreCommand,-4,CMD_WRITE|CMD_DENYOOM|CMD_ASKING,ACL_CATEGORY_KEYSPACE|ACL_CATEGORY_DANGEROUS,RESTORE_ASKING_Keyspecs,1,NULL,7),.args=RESTORE_ASKING_Args},
 {MAKE_CMD("role","Returns the replication role.","O(1)","2.8.12",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,ROLE_History,0,ROLE_Tips,0,roleCommand,1,CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_FAST|CMD_SENTINEL,ACL_CATEGORY_ADMIN|ACL_CATEGORY_DANGEROUS,ROLE_Keyspecs,0,NULL,0)},
 {MAKE_CMD("save","Synchronously saves the database(s) to disk.","O(N) where N is the total number of keys in all databases","1.0.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,SAVE_History,0,SAVE_Tips,0,saveCommand,1,CMD_NO_ASYNC_LOADING|CMD_ADMIN|CMD_NOSCRIPT|CMD_NO_MULTI,0,SAVE_Keyspecs,0,NULL,0)},
+{MAKE_CMD("sflush","Remove all keys from selected range of slots.","O(N)+O(k) where N is the number of keys and k is the number of slots.","8.0.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,SFLUSH_History,0,SFLUSH_Tips,0,sflushCommand,-3,CMD_WRITE,ACL_CATEGORY_KEYSPACE|ACL_CATEGORY_DANGEROUS,SFLUSH_Keyspecs,0,NULL,2),.args=SFLUSH_Args},
 {MAKE_CMD("shutdown","Synchronously saves the database(s) to disk and shuts down the Redis server.","O(N) when saving, where N is the total number of keys in all databases when saving data, otherwise O(1)","1.0.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,SHUTDOWN_History,1,SHUTDOWN_Tips,0,shutdownCommand,-1,CMD_ADMIN|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_NO_MULTI|CMD_SENTINEL|CMD_ALLOW_BUSY,0,SHUTDOWN_Keyspecs,0,NULL,4),.args=SHUTDOWN_Args},
 {MAKE_CMD("slaveof","Sets a Redis server as a replica of another, or promotes it to being a master.","O(1)","1.0.0",CMD_DOC_DEPRECATED,"`REPLICAOF`","5.0.0","server",COMMAND_GROUP_SERVER,SLAVEOF_History,0,SLAVEOF_Tips,0,replicaofCommand,3,CMD_NO_ASYNC_LOADING|CMD_ADMIN|CMD_NOSCRIPT|CMD_STALE,0,SLAVEOF_Keyspecs,0,NULL,1),.args=SLAVEOF_Args},
 {MAKE_CMD("slowlog","A container for slow log commands.","Depends on subcommand.","2.2.12",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,SLOWLOG_History,0,SLOWLOG_Tips,0,NULL,-2,0,0,SLOWLOG_Keyspecs,0,NULL,0),.subcommands=SLOWLOG_Subcommands},

--- a/src/commands/sflush.json
+++ b/src/commands/sflush.json
@@ -7,8 +7,7 @@
         "arity": -3,
         "function": "sflushCommand",
         "command_flags": [
-            "WRITE",
-            "EXPERIMENTAL"
+            "WRITE"
         ],
         "acl_categories": [
             "KEYSPACE",

--- a/src/db.c
+++ b/src/db.c
@@ -1003,13 +1003,13 @@ void flushAllDataAndResetRDB(int flags) {
  *
  * Utilized by commands SFLUSH, FLUSHALL and FLUSHDB.
  */
-void flushallSyncBgDone(uint64_t client_id, void *sflush) {
-    slotRangeArray *slotsFlush = sflush;
+void flushallSyncBgDone(uint64_t client_id, void *userdata) {
+    slotRangeArray *sra = userdata;
     client *c = lookupClientByID(client_id);
 
     /* Verify that client still exists and being blocked. */
     if (!(c && c->flags & CLIENT_BLOCKED)) {
-        zfree(sflush);
+        zfree(sra);
         return;
     }
 
@@ -1020,9 +1020,9 @@ void flushallSyncBgDone(uint64_t client_id, void *sflush) {
     /* Don't update blocked_us since command was processed in bg by lazy_free thread */
     updateStatsOnUnblock(c, 0 /*blocked_us*/, elapsedUs(c->bstate.lazyfreeStartTime), 0);
 
-    /* Only SFLUSH command pass pointer to `SlotsFlush` */
-    if (slotsFlush)
-        replySlotsFlushAndFree(c, slotsFlush);
+    /* Only SFLUSH command pass userdata pointer. */
+    if (sra)
+        replySlotsFlushAndFree(c, sra);
     else
         addReply(c, shared.ok);
 
@@ -1044,16 +1044,16 @@ void flushallSyncBgDone(uint64_t client_id, void *sflush) {
     server.current_client = old_client;
 }
 
-/* Common flush command implementation for FLUSHALL and FLUSHDB.
+/* Common flush command implementation for FLUSHALL, FLUSHDB and SFLUSH.
  *
  * Return 1 indicates that flush SYNC is actually running in bg as blocking ASYNC
  * Return 0 otherwise
  *
- * sflush - provided only by SFLUSH command, otherwise NULL. Will be used on 
- *          completion to reply with the slots flush result. Ownership is passed
- *          to the completion job in case of `blocking_async`.
+ * sra - provided only by SFLUSH command, otherwise NULL. Will be used on
+ *       completion to reply with the slots flush result. Ownership is passed
+ *       to the completion job in case of `blocking_async`.
  */
-int flushCommandCommon(client *c, int type, int flags, slotRangeArray *sflush) {
+int flushCommandCommon(client *c, int type, int flags, slotRangeArray *sra) {
     int blocking_async = 0; /* Flush SYNC option to run as blocking ASYNC */
 
     /* in case of SYNC, check if we can optimize and run it in bg as blocking ASYNC */
@@ -1063,10 +1063,17 @@ int flushCommandCommon(client *c, int type, int flags, slotRangeArray *sflush) {
         blocking_async = 1;
     }
 
-    if (type == FLUSH_TYPE_ALL)
+    if (type == FLUSH_TYPE_ALL) {
         flushAllDataAndResetRDB(flags | EMPTYDB_NOFUNCTIONS);
-    else
-        server.dirty += emptyData(c->db->id,flags | EMPTYDB_NOFUNCTIONS,NULL);
+    } else if (type == FLUSH_TYPE_DB) {
+        server.dirty += emptyData(c->db->id, flags | EMPTYDB_NOFUNCTIONS, NULL);
+    } else {
+        serverAssert(type == FLUSH_TYPE_SLOTS);
+        int delkeys_flags = CLUSTER_DELKEYS_BY_COMMAND;
+        if (flags & EMPTYDB_ASYNC)
+            delkeys_flags |= CLUSTER_DELKEYS_ASYNC;
+        clusterDelKeysInSlotRangeArray(sra, delkeys_flags);
+    }
 
     /* Without the forceCommandPropagation, when DB(s) was already empty,
      * FLUSHALL\FLUSHDB will not be replicated nor put into the AOF. */
@@ -1085,7 +1092,7 @@ int flushCommandCommon(client *c, int type, int flags, slotRangeArray *sflush) {
          * avoid command from being reset during unblock. */
         c->flags |= CLIENT_PENDING_COMMAND;
         blockClient(c,BLOCKED_LAZYFREE);
-        bioCreateCompRq(BIO_WORKER_LAZY_FREE, flushallSyncBgDone, c->id, sflush);
+        bioCreateCompRq(BIO_WORKER_LAZY_FREE, flushallSyncBgDone, c->id, sra);
     }
 
 #if defined(USE_JEMALLOC)

--- a/tests/unit/cluster/multi-slot-operations.tcl
+++ b/tests/unit/cluster/multi-slot-operations.tcl
@@ -108,7 +108,7 @@ test "DELSLOTSRANGE command with several boundary conditions test suite" {
 }
 } cluster_allocate_with_continuous_slots_local
 
-start_cluster 2 0 {tags {external:skip cluster experimental}} {
+start_cluster 2 0 {tags {external:skip cluster}} {
 
 set master1 [srv 0 "client"]
 set master2 [srv -1 "client"]
@@ -133,20 +133,20 @@ test "SFLUSH - Errors and output validation" {
     assert_error {ERR wrong number of arguments*}           {$master1 SFLUSH 0 999 2001 8191 ASYNCX}
 
     # Test SFLUSH output validation
-    assert_match "" [$master1 SFLUSH 2 4]
-    assert_match "" [$master1 SFLUSH 0 4]
+    assert_match "{2 4}" [$master1 SFLUSH 2 4]
+    assert_match "{0 4}" [$master1 SFLUSH 0 4]
     assert_match "" [$master2 SFLUSH 0 4]
-    assert_match "" [$master1 SFLUSH 1 8191]
-    assert_match "" [$master1 SFLUSH 0 8190]
-    assert_match "" [$master1 SFLUSH 0 998 2001 8191]
-    assert_match "" [$master1 SFLUSH 1 999 2001 8191]
-    assert_match "" [$master1 SFLUSH 0 999 2001 8190]
-    assert_match "" [$master1 SFLUSH 0 999 2002 8191]
+    assert_match "{1 999} {2001 8191}" [$master1 SFLUSH 1 8191]
+    assert_match "{0 999} {2001 8190}" [$master1 SFLUSH 0 8190]
+    assert_match "{0 998} {2001 8191}" [$master1 SFLUSH 0 998 2001 8191]
+    assert_match "{1 999} {2001 8191}" [$master1 SFLUSH 1 999 2001 8191]
+    assert_match "{0 999} {2001 8190}" [$master1 SFLUSH 0 999 2001 8190]
+    assert_match "{0 999} {2002 8191}" [$master1 SFLUSH 0 999 2002 8191]
     assert_match "{0 999} {2001 8191}" [$master1 SFLUSH 0 999 2001 8191]
     assert_match "{0 999} {2001 8191}" [$master1 SFLUSH 0 8191]
     assert_match "{0 999} {2001 8191}" [$master1 SFLUSH 0 4000 4001 8191]
-    assert_match "" [$master2 SFLUSH 8193 16383]
-    assert_match "" [$master2 SFLUSH 8192 16382]
+    assert_match "{8193 16383}" [$master2 SFLUSH 8193 16383]
+    assert_match "{8192 16382}" [$master2 SFLUSH 8192 16382]
     assert_match "{8192 16383}" [$master2 SFLUSH 8192 16383]
     assert_match "{8192 16383}" [$master2 SFLUSH 8192 16383 SYNC]
     assert_match "{8192 16383}" [$master2 SFLUSH 8192 16383 ASYNC]


### PR DESCRIPTION
- Add partial flush support to SFLUSH command: Currently, flush operation is not efficient. It iterates the keys to call KSN function etc. We can cleanup whole slots dict more efficiently in the BIO thread. We should revisit this and improve the performance in future once we decide how to handle this case. 
- Minor fix for printing replica port number in logs. 