### PR TITLE
Asm error handler

### DIFF
--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -166,7 +166,7 @@ int asmTaskSetFailPoint(sds channel, sds state) {
     asmManager->failed_state = 0;
     if (!channel && !state) return C_ERR;
     if (sdslen(channel) == 0 && sdslen(state) == 0) {
-        serverLog(LL_WARNING, "Fail point is cleared");
+        serverLog(LL_WARNING, "ASM fail point is cleared");
         return C_OK;
     }
 
@@ -191,7 +191,7 @@ int asmTaskSetFailPoint(sds channel, sds state) {
     else if (!strcasecmp(state, "rdbchannel-transfer")) asmManager->failed_state = ASM_RDBCHANNEL_TRANSFER;
     else return C_ERR;
 
-    serverLog(LL_NOTICE, "Fail point set: channel=%s, state=%s", channel, state);
+    serverLog(LL_NOTICE, "ASM fail point set: channel=%s, state=%s", channel, state);
     return C_OK;
 }
 
@@ -1080,7 +1080,7 @@ void asmSyncWithSource(connection *conn) {
     return;
 
 no_response_error:
-    serverLog(LL_WARNING, "Source node did not respond to command during SYNC handshake");
+    serverLog(LL_WARNING, "Source node did not respond to command during SYNCSLOTS handshake");
     /* Fall through to regular error handling */
 
 error:
@@ -1520,8 +1520,8 @@ werr:
 
 /* Read error handler for sync buffer */
 static void asmReadSyncBufferErrorHandler(connection *conn) {
-    serverLog(LL_WARNING, "ASM buffer stream: error while reading from source: %s",
-              connGetLastError(conn));
+    serverLog(LL_WARNING, "Import main channel buffer stream read error: %s",
+                          connGetLastError(conn));
     asmTask *task = connGetPrivateData(conn);
     asmTaskSetError(task, "Import main channel buffer stream read error: %s, state: %s",
                           connGetLastError(conn), asmTaskStateToString(task->state));
@@ -1540,7 +1540,7 @@ static void asmSyncBufferStreamYieldCallback(void *ctx) {
     replDataBufToDbCtx *context = ctx;
     client *c = context->client;
 
-    sds offset = sdsfromlonglong(context->total_offset);
+    sds offset = sdsfromlonglong(context->applied_offset);
     char *err = sendCommand(c->conn, "CLUSTER", "SYNCSLOTS", "ACK", offset, NULL);
     sdsfree(offset);
     if (!err) return;
@@ -1548,9 +1548,8 @@ static void asmSyncBufferStreamYieldCallback(void *ctx) {
     serverLog(LL_WARNING, "Error sending CLUSTER SYNCSLOTS ACK: %s", err);
     sdsfree(err);
 
-    /* Mask this client as closed, and then asmSyncBufferStreamShouldContinue
-     * will this error, and then stop this task. */
-    c->flags |= CLIENT_CLOSE_ASAP;
+    /* Since this client is protected, freeClient just masks it as closed */
+    freeClientAsync(c);
 }
 
 static int asmSyncBufferStreamShouldContinue(void *ctx) {
@@ -1589,7 +1588,7 @@ void asmSyncBufferStreamToDb(asmTask *task) {
 
     replDataBufToDbCtx ctx = {
         .client = c,
-        .total_offset = 0,
+        .applied_offset = 0,
         .should_continue = asmSyncBufferStreamShouldContinue,
         .yield_callback = asmSyncBufferStreamYieldCallback,
     };
@@ -1601,11 +1600,13 @@ void asmSyncBufferStreamToDb(asmTask *task) {
 
     if (ret == C_OK) {
         /* Update the dest offset according to applied bytes. */
-        task->dest_offset = ctx.total_offset;
+        task->dest_offset = ctx.applied_offset;
         /* Wait STREAM-EOF from the source node. */
         task->state = ASM_WAIT_STREAM_EOF;
         connSetReadHandler(task->main_channel_conn, readQueryFromClient);
-        serverLog(LL_NOTICE, "Streaming buffer for task is done, size: %lld", task->dest_offset);
+        serverLog(LL_NOTICE, "Streaming buffer for task is done, applied offset: %lld",
+                             task->dest_offset);
+
         if (unlikely(asmIsFailPointActive(ASM_IMPORT_MAIN_CHANNEL, task->state)))
             connShutdown(task->main_channel_conn); /* Simulate a failure */
 
@@ -1649,9 +1650,9 @@ void asmBeforeSleep(void) {
     if (task->operation == ASM_MIGRATE) {
         if (task->state == ASM_PAUSED_WRITE) {
             client *c = task->main_channel_client;
-            /* All slot ranges command stream drained */
+            /* The command streams for slot ranges have been drained. */
             if (!clientHasPendingReplies(c)) {
-                serverLog(LL_NOTICE, "All slot ranges command stream drained, sending STREAM-EOF");
+                serverLog(LL_NOTICE, "The command streams for slot ranges have been drained, sending STREAM-EOF");
 
                 if (unlikely(asmIsFailPointActive(ASM_MIGRATE_MAIN_CHANNEL, task->state)))
                     connShutdown(c->conn);
@@ -1667,8 +1668,12 @@ void asmBeforeSleep(void) {
                     return;
                 }
 
-                /* Free clients since they are no longer needed */
-                asmMigrateCloseClients(task);
+               /* Even though the main channel client is no longer needed, we can't
+                * close it directly because the destination may still be sending ACKs
+                * over this connection. Instead, we leave it to the destination to
+                * close it. We just clear the task and client references */
+                task->main_channel_client->task = NULL;
+                task->main_channel_client = NULL;
 
                 task->state = ASM_STREAM_DONE;
                 /* Notify plugin import is completed */

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -15,6 +15,8 @@
 #define ASM_IMPORT  (1 << 1)
 #define ASM_MIGRATE (1 << 2)
 
+#define ASM_PAUSE_WRITE_MAX_GAP_BYTES (1024 * 1024) /* 1MB */
+
 typedef struct asmTask {
     int operation;                      /* Either ASM_IMPORT or ASM_MIGRATE */
     slotRangeArray *slot_ranges;        /* List of slot ranges for this migration operation */
@@ -30,11 +32,13 @@ typedef struct asmTask {
     long long source_offset;            /* Source offset */
     replDataBuf sync_buffer;            /* Buffer for the stream */
     client *main_channel_client;        /* Client for the main channel on the source side */
+    client *rdb_channel_client;         /* Client for the RDB channel on the source side */
     long long retry_count;              /* Number of retries for this task */
     mstime_t create_time;               /* The time of creating this task */
     mstime_t start_time;                /* The start time of this task */
     mstime_t done_time;                 /* The completed time of this task */
     mstime_t paused_time;               /* The time when the slot writes are paused */
+    sds error;                          /* Error message for this task */
 } asmTask;
 
 struct asmManager {
@@ -42,11 +46,15 @@ struct asmManager {
     list *done_tasks;             /* List of completed asmTask */
     size_t sync_buffer_peak;      /* Peak size of sync buffer */
     long long total_done_tasks;   /* Total number of completed tasks */
+
+    /* Fail point injection */
+    int failed_channel;           /* Channel in which the task failed */
+    int failed_state;             /* State in which the task failed */
 };
 
 enum asmState {
     /* Common state */
-    ASM_NONE,
+    ASM_NONE = 0,
     ASM_CONNECTING,
     ASM_AUTH_REPLY,
     ASM_CANCELED,
@@ -79,6 +87,13 @@ enum asmState {
     ASM_RDBCHANNEL_DONE
 };
 
+enum asmChannel {
+    ASM_IMPORT_MAIN_CHANNEL = 1,   /* Main channel for the import task */
+    ASM_IMPORT_RDB_CHANNEL,        /* RDB channel for the import task */
+    ASM_MIGRATE_MAIN_CHANNEL,      /* Main channel for the migrate task */
+    ASM_MIGRATE_RDB_CHANNEL        /* RDB channel for the migrate task */
+};
+
 /* Global ASM manager */
 struct asmManager *asmManager = NULL;
 
@@ -92,6 +107,7 @@ void createDumpPayload(rio *payload, robj *o, robj *key, int dbid);
 int startBgsaveForReplication(int mincapa, int req);
 void createReplicationBacklogIfNeeded(void);
 static void asmSyncBufferReadFromConn(connection *conn);
+unsigned int delKeysInSlot(unsigned int hashslot);
 
 void clusterAsmInit(void) {
     asmManager = zcalloc(sizeof(*asmManager));
@@ -99,6 +115,8 @@ void clusterAsmInit(void) {
     asmManager->done_tasks = listCreate();
     asmManager->sync_buffer_peak = 0;
     asmManager->total_done_tasks = 0;
+    asmManager->failed_channel = 0;
+    asmManager->failed_state = 0;
 }
 
 char *asmTaskStateToString(int state) {
@@ -129,9 +147,74 @@ char *asmTaskStateToString(int state) {
         case ASM_PAUSED_WRITE: return "paused-write";
         case ASM_STREAM_DONE: return "stream-done";
 
+        /* RDB channel state */
+        case ASM_SEND_RDBCHANNEL: return "send-rdbchannel";
+        case ASM_RDBCHANNEL_REPLY: return "rdbchannel-reply";
+        case ASM_RDBCHANNEL_TRANSFER: return "rdbchannel-transfer";
+        case ASM_RDBCHANNEL_DONE: return "rdbchannel-done";
+
         default: return "unknown";
     }
     return NULL; /* Unreachable */
+}
+
+int asmTaskSetFailPoint(const char *channel, const char *state) {
+    if (!asmManager) {
+        serverLog(LL_WARNING, "ASM manager is not initialized");
+        return C_ERR;
+    }
+    asmManager->failed_channel = 0;
+    asmManager->failed_state = 0;
+    if (!channel && !state) {
+        serverLog(LL_WARNING, "Fail point is cleared");
+        return C_OK;
+    }
+
+    if (!strcasecmp(channel, "import-main-channel")) asmManager->failed_channel = ASM_IMPORT_MAIN_CHANNEL;
+    else if (!strcasecmp(channel, "import-rdb-channel")) asmManager->failed_channel = ASM_IMPORT_RDB_CHANNEL;
+    else if (!strcasecmp(channel, "migrate-main-channel")) asmManager->failed_channel = ASM_MIGRATE_MAIN_CHANNEL;
+    else if (!strcasecmp(channel, "migrate-rdb-channel")) asmManager->failed_channel = ASM_MIGRATE_RDB_CHANNEL;
+    else return C_ERR;
+
+    if (!strcasecmp(state, "connecting")) asmManager->failed_state = ASM_CONNECTING;
+    else if (!strcasecmp(state, "auth-reply")) asmManager->failed_state = ASM_AUTH_REPLY;
+    else if (!strcasecmp(state, "handshake-reply")) asmManager->failed_state = ASM_HANDSHAKE_REPLY;
+    else if (!strcasecmp(state, "syncslots-reply")) asmManager->failed_state = ASM_SYNCSLOTS_REPLY;
+    else if (!strcasecmp(state, "accumulate-buffer")) asmManager->failed_state = ASM_ACCUMULATE_BUF;
+    else if (!strcasecmp(state, "streaming-buffer")) asmManager->failed_state = ASM_STREAMING_BUF;
+    else if (!strcasecmp(state, "wait-stream-eof")) asmManager->failed_state = ASM_WAIT_STREAM_EOF;
+    else if (!strcasecmp(state, "wait-rdbchannel")) asmManager->failed_state = ASM_WAIT_RDBCHANNEL;
+    else if (!strcasecmp(state, "wait-bgsave-start")) asmManager->failed_state = ASM_WAIT_BGSAVE_START;
+    else if (!strcasecmp(state, "send-bulk-and-stream")) asmManager->failed_state = ASM_SEND_BULK_AND_STREAM;
+    else if (!strcasecmp(state, "wait-pause-write")) asmManager->failed_state = ASM_WAIT_PAUSE_WRITE;
+    else if (!strcasecmp(state, "paused-write")) asmManager->failed_state = ASM_PAUSED_WRITE;
+    else if (!strcasecmp(state, "rdbchannel-reply")) asmManager->failed_state = ASM_RDBCHANNEL_REPLY;
+    else if (!strcasecmp(state, "rdbchannel-transfer")) asmManager->failed_state = ASM_RDBCHANNEL_TRANSFER;
+    else return C_ERR;
+
+    serverLog(LL_NOTICE, "Fail point set: channel=%s, state=%s", channel, state);
+    return C_OK;
+}
+
+const char *asmChannelToString(int channel) {
+    switch (channel) {
+        case ASM_IMPORT_MAIN_CHANNEL: return "import-main-channel";
+        case ASM_IMPORT_RDB_CHANNEL: return "import-rdb-channel";
+        case ASM_MIGRATE_MAIN_CHANNEL: return "migrate-main-channel";
+        case ASM_MIGRATE_RDB_CHANNEL: return "migrate-rdb-channel";
+        default: return "unknown";
+    }
+}
+
+int asmIsFailPointActive(int channel, int state) {
+    if (!asmManager) return 0; /* No ASM manager initialized */
+    if (asmManager->failed_channel == channel &&
+            asmManager->failed_state == state) {
+        serverLog(LL_NOTICE, "ASM fail point active: channel=%d, state=%d",
+                  channel, state);
+        return 1;
+    }
+    return 0;
 }
 
 void asmTaskReset(asmTask *task) {
@@ -140,13 +223,16 @@ void asmTaskReset(asmTask *task) {
     task->main_channel_id = -1;
     task->main_channel_conn = NULL;
     task->rdb_channel_conn = NULL;
-    task->dest_offset = -1;
-    task->source_offset = -1;
+    task->dest_offset = 0;
+    task->source_offset = 0;
     replDataBufInit(&task->sync_buffer);
+    sdsfree(task->error);
+    task->error = sdsempty();    
 }
 
 asmTask *asmTaskCreate(void) {
     asmTask *task = zcalloc(sizeof(*task));
+    task->error = sdsempty();
     asmTaskReset(task);
     task->slot_ranges = NULL;
     task->source_node = NULL;
@@ -157,6 +243,21 @@ asmTask *asmTaskCreate(void) {
     task->done_time = 0;
 
     return task;
+}
+
+static void asmMigrateCloseClients(asmTask *task) {
+    serverAssert(task->operation == ASM_MIGRATE);
+
+    if (task->main_channel_client) {
+        freeClientAsync(task->main_channel_client);
+        task->main_channel_client->task = NULL;
+        task->main_channel_client = NULL;
+    }
+    if (task->rdb_channel_client) {
+        freeClientAsync(task->rdb_channel_client);
+        task->rdb_channel_client->task = NULL;
+        task->rdb_channel_client = NULL;
+    }
 }
 
 static int compareSlotRange(const void *a, const void *b) {
@@ -343,9 +444,14 @@ void asmFeedMigrationClient(robj **argv, int argc) {
 
     /* Feed main channel with the command. */
     client *c = task->main_channel_client;
+    size_t prev_bytes = getNormalClientPendingReplyBytes(c);
+
     addReplyArrayLen(c, argc);
     for (int i = 0; i < argc; i++)
         addReplyBulk(c, argv[i]);
+
+    /* Update the task's source offset to reflect the bytes sent. */
+    task->source_offset += (getNormalClientPendingReplyBytes(c) - prev_bytes);
 }
 
 int asmStartImportTask(slotRangeArray *slot_ranges, sds *err) {
@@ -477,7 +583,7 @@ static void clusterMigrationCommandCancel(client *c) {
 static void replyTaskStatus(client *c, asmTask *task) {
     mstime_t p = 0;
 
-    addReplyMapLen(c, 6);
+    addReplyMapLen(c, 7);
     addReplyBulkCString(c, "slots_range");
     addReplyBulkSds(c, createSlotRangesStr(task->slot_ranges));
     addReplyBulkCString(c, "source");
@@ -488,6 +594,8 @@ static void replyTaskStatus(client *c, asmTask *task) {
     addReplyBulkCString(c, task->operation == ASM_IMPORT ? "importing" : "migrating");
     addReplyBulkCString(c, "state");
     addReplyBulkCString(c, asmTaskStateToString(task->state));
+    addReplyBulkCString(c, "error");
+    addReplyBulkCBuffer(c, task->error, sdslen(task->error));
 
     if (task->operation == ASM_MIGRATE && task->state == ASM_DONE)
         p = task->done_time - task->paused_time;
@@ -534,6 +642,18 @@ void clusterMigrationCommand(client *c) {
     }
 }
 
+void asmTaskSetError(asmTask *task, const char *fmt, ...) {
+    va_list ap;
+    sds error = sdsempty();
+
+    va_start(ap, fmt);
+    error = sdscatvprintf(error, fmt, ap);
+    va_end(ap);
+
+    if (task->error) sdsfree(task->error);
+    task->error = error;
+}
+
 void asmImportFailed(asmTask *task) {
     serverAssert(task->operation == ASM_IMPORT);
 
@@ -543,6 +663,17 @@ void asmImportFailed(asmTask *task) {
         client *c = connGetPrivateData(task->rdb_channel_conn);
         serverAssert(c->task == task);
         task->rdb_channel_conn = NULL;
+        c->task = NULL;
+        c->flags &= ~CLIENT_MASTER;
+        freeClientAsync(c);
+    }
+
+    /* If we are in the wait stream EOF state, we need to close the
+     * client that was created for the main channel. */
+    if (task->main_channel_conn && task->state == ASM_WAIT_STREAM_EOF) {
+        client *c = connGetPrivateData(task->main_channel_conn);
+        serverAssert(c->task == task);
+        task->main_channel_conn = NULL;
         c->task = NULL;
         c->flags &= ~CLIENT_MASTER;
         freeClientAsync(c);
@@ -566,6 +697,22 @@ void asmImportFailed(asmTask *task) {
     clusterAsmOnEvent(task->slot_ranges, ASM_EVENT_IMPORT_FAILED, NULL);
 }
 
+void asmMigrateFailed(asmTask *task) {
+    serverAssert(task->operation == ASM_MIGRATE);
+
+    /* Clients cleanup */
+    asmMigrateCloseClients(task);
+
+    sds slot_ranges_str = createSlotRangesStr(task->slot_ranges);
+    serverLog(LL_WARNING, "Migrate operation failed for source: %s, dest: %s, slots: %s",
+              task->source, task->dest, slot_ranges_str);
+    sdsfree(slot_ranges_str);
+
+    /* Mark the task as failed and notify the cluster */
+    task->state = ASM_FAILED;
+    clusterAsmOnEvent(task->slot_ranges, ASM_EVENT_MIGRATE_FAILED, NULL);
+}
+
 void asmCallbackOnFreeClient(client *c) {
     asmTask *task = c->task;
     if (!task) return;
@@ -575,7 +722,41 @@ void asmCallbackOnFreeClient(client *c) {
         /* We create the client only when transferring data on the RDB channel */
         serverAssert(task->rdb_channel_state == ASM_RDBCHANNEL_TRANSFER);
         task->rdb_channel_conn = NULL; /* Will be freed by freeClient */
+        c->flags &= ~CLIENT_MASTER;
+        asmTaskSetError(task, "Import rdb channel connection is closed, state: %s",
+                              asmTaskStateToString(task->rdb_channel_state));
         asmImportFailed(task);
+        return;
+    }
+
+    if (c->conn && task->main_channel_conn == c->conn) {
+        /* After streaming buffer to DB, the client has the chance to close */
+        serverAssert(task->state == ASM_WAIT_STREAM_EOF);
+        task->main_channel_conn = NULL; /* Will be freed by freeClient */
+        c->flags &= ~CLIENT_MASTER;
+        asmTaskSetError(task, "Import main channel connection is closed, state: %s",
+                              asmTaskStateToString(task->state));
+        asmImportFailed(task);
+        return;
+    }
+
+    if (c == task->rdb_channel_client) {
+        /* We may not have detected whether the child process has exited yet,
+         * so we can’t determine whether the client has completed the slots
+         * snapshot transfer. If the RDB channel is interrupted unexpectedly,
+         * the destination side will also close the main channel.
+         * So here we just reset the RDB channel client of task. */
+        task->rdb_channel_client = NULL;
+        c->task = NULL; /* Clear the task reference */
+        return;
+    }
+
+    /* If the main channel client is closed, we need to mark the task as failed
+     * and clean up the RDB channel client if it exists. */
+    if (c == task->main_channel_client) {
+        asmTaskSetError(task, "Migrate main channel client is closed, state: %s",
+                              asmTaskStateToString(task->state));
+        asmMigrateFailed(task);
         return;
     }
 }
@@ -599,6 +780,7 @@ char *asmSendInternalAuth(connection *conn) {
 void asmRdbChannelSyncWithSource(connection *conn) {
     asmTask *task = connGetPrivateData(conn);
     char *err = NULL;
+    sds task_error_msg = NULL;
 
     /* Check for errors in the socket: after a non blocking connect() we
      * may find that the socket is in error state. */
@@ -606,6 +788,12 @@ void asmRdbChannelSyncWithSource(connection *conn) {
         serverLog(LL_WARNING, "Error condition on socket for establishing rdb channel: %s",
                 connGetLastError(conn));
         goto error;
+    }
+
+    /* Check if the task is in a fail point state */
+    if (unlikely(asmIsFailPointActive(ASM_IMPORT_RDB_CHANNEL, task->rdb_channel_state))) {
+        /* Simulate a failure */
+        connShutdown(conn);
     }
 
     if (task->rdb_channel_state == ASM_CONNECTING) {
@@ -631,7 +819,9 @@ void asmRdbChannelSyncWithSource(connection *conn) {
             task->rdb_channel_state = ASM_SEND_RDBCHANNEL;
             serverLog(LL_NOTICE, "Source node replied to AUTH command, slots rdb channel sync can continue...");
         } else {
-            serverLog(LL_WARNING, "Error reply to AUTH from source: '%s'", err);
+            task_error_msg = sdscatprintf(sdsempty(),
+                "Error reply to AUTH from source: %s", err);
+            serverLog(LL_WARNING, "Error reply to AUTH from source: %s", err);
             sdsfree(err);
             goto error;
         }
@@ -666,10 +856,12 @@ void asmRdbChannelSyncWithSource(connection *conn) {
             c->user = NULL;
             c->task = task;
             serverLog(LL_NOTICE,
-                "Source replied to SLOTSSNAPSHOT, sync slots snapshot can continue...");
+                "Source node replied to SLOTSSNAPSHOT, sync slots snapshot can continue...");
             sdsfree(err);
         } else {
-            serverLog(LL_WARNING,"Error reply to CLUSTER SYNCSLOTS RDBCHANNEL from the source: '%s'",err);
+            task_error_msg = sdscatprintf(sdsempty(),
+                "Error reply to CLUSTER SYNCSLOTS RDBCHANNEL from the source: %s", err);
+            serverLog(LL_WARNING,"Error reply to CLUSTER SYNCSLOTS RDBCHANNEL from the source: %s", err);
             sdsfree(err);
             goto error;
         }
@@ -682,7 +874,11 @@ no_response_error:
     /* Fall through to regular error handling */
 
 error:
+    asmTaskSetError(task, "Import rdb channel failed to sync with source node: %s, state: %s",
+                          task_error_msg ? task_error_msg : connGetLastError(conn),
+                          asmTaskStateToString(task->rdb_channel_state));
     asmImportFailed(task);
+    sdsfree(task_error_msg);
     return;
 
 write_error: /* Handle sendCommand() errors. */
@@ -732,12 +928,21 @@ void asmSyncWithSource(connection *conn) {
     asmTask *task = connGetPrivateData(conn);
     char *err = NULL;
 
+    /* Some task errors are not network issues, we record them explicitly. */
+    sds task_error_msg = NULL;
+
     /* Check for errors in the socket: after a non blocking connect() we
      * may find that the socket is in error state. */
     if (connGetState(conn) != CONN_STATE_CONNECTED) {
         serverLog(LL_WARNING, "Error condition on socket for sync slots: %s",
                 connGetLastError(conn));
         goto error;
+    }
+
+    /* Check if the fail point is active for this channel and state */
+    if (unlikely(asmIsFailPointActive(ASM_IMPORT_MAIN_CHANNEL, task->state))) {
+        /* Simulate a failure */
+        connShutdown(conn);
     }
 
     if (task->state == ASM_CONNECTING) {
@@ -762,7 +967,9 @@ void asmSyncWithSource(connection *conn) {
             task->state = ASM_SEND_HANDSHAKE;
             serverLog(LL_NOTICE, "Source node replied to AUTH command, sync slots can continue...");
         } else {
-            serverLog(LL_WARNING, "Error reply to AUTH from the source: '%s'", err);
+            task_error_msg = sdscatprintf(sdsempty(),
+                "Error reply to AUTH from the source: %s", err);
+            serverLog(LL_WARNING, "Error reply to AUTH from the source: %s", err);
             sdsfree(err);
             goto error;
         }
@@ -789,7 +996,9 @@ void asmSyncWithSource(connection *conn) {
             task->state = ASM_SEND_SYNCSLOTS;
             serverLog(LL_NOTICE, "Source node replied to SYNCSLOTS CONF command, sync slots can continue...");
         } else {
-            serverLog(LL_WARNING, "Error reply to SYNCSLOTS CONF from the source: '%s'", err);
+            task_error_msg = sdscatprintf(sdsempty(),
+                "Error reply to CLUSTER SYNCSLOTS CONF from the source: %s", err);
+            serverLog(LL_WARNING, "Error reply to SYNCSLOTS CONF from the source: %s", err);
             sdsfree(err);
             goto error;
         }
@@ -814,19 +1023,23 @@ void asmSyncWithSource(connection *conn) {
             char *client_id = strchr(err,' ');
             if (client_id) client_id++;
             if (!client_id) {
+                task_error_msg = sdscatprintf(sdsempty(),
+                    "Source node replied with wrong +RDBCHANNELSYNCSLOTS syntax: %s", err);
                 serverLog(LL_WARNING,
-                            "Source replied with wrong +RDBCHANNELSYNC syntax: %s", err);
+                            "Source node replied with wrong +RDBCHANNELSYNC syntax: %s", err);
                 sdsfree(err);
                 goto error;
             }
             task->main_channel_id = strtoll(client_id, NULL, 10);
             serverLog(LL_NOTICE,
-                "Source replied to RDBCHANNELSYNCSLOTS, sync slots can continue...");
+                "Source node replied to RDBCHANNELSYNCSLOTS, sync slots can continue...");
             sdsfree(err);
             err = NULL;
             task->state = ASM_INIT_RDBCHANNEL;
         } else {
-            serverLog(LL_WARNING, "Error reply to SYNCSLOTS RANGES from the source: '%s'", err);
+            task_error_msg = sdscatprintf(sdsempty(),
+                "Error reply to CLUSTER SYNCSLOTS RANGES from the source: %s", err);
+            serverLog(LL_WARNING, "Error reply to SYNCSLOTS RANGES from the source: %s", err);
             sdsfree(err);
             goto error;
         }
@@ -860,13 +1073,32 @@ no_response_error:
     /* Fall through to regular error handling */
 
 error:
+    asmTaskSetError(task, "Import main channel failed to sync with source node: %s, state: %s",
+                          task_error_msg ? task_error_msg : connGetLastError(conn),
+                          asmTaskStateToString(task->state));
     asmImportFailed(task);
+    sdsfree(task_error_msg);
     return;
 
 write_error: /* Handle sendCommand() errors. */
     serverLog(LL_WARNING, "Failed sending command to source: %s", err);
     sdsfree(err);
     goto error;
+}
+
+void asmImportSendACK(asmTask *task) {
+    serverAssert(task->operation == ASM_IMPORT && task->state == ASM_WAIT_STREAM_EOF);
+
+    sds offset = sdsfromlonglong(task->dest_offset);
+    char *err = sendCommand(task->main_channel_conn, "CLUSTER", "SYNCSLOTS", "ACK", offset, NULL);
+    sdsfree(offset);
+    if (err == NULL) return;
+
+    serverLog(LL_WARNING, "Error sending CLUSTER SYNCSLOTS ACK: %s", err);
+    asmTaskSetError(task, "Import main channel sending ACK failed: %s, state: %s",
+                            err, asmTaskStateToString(task->state));
+    asmImportFailed(task);
+    sdsfree(err);
 }
 
 void asmStartSendBulkAndStream(struct asmTask *task) {
@@ -889,6 +1121,18 @@ void clusterSyncSlotsSnapshotEOF(client *c) {
                               "rdb channel state: %s",
                               asmTaskStateToString(task ? task->rdb_channel_state : ASM_NONE));
         freeClientAsync(c);
+        return;
+    }
+
+    /* RDB channel state: ASM_RDBCHANNEL_TRANSFER */
+    if (unlikely(asmIsFailPointActive(ASM_IMPORT_RDB_CHANNEL, task->rdb_channel_state))) {
+        freeClientAsync(c); /* Simulate a failure */
+        return;
+    }
+    /* Main channel state: ASM_ACCUMULATE_BUF */
+    serverAssert(task->state == ASM_ACCUMULATE_BUF);
+    if (unlikely(asmIsFailPointActive(ASM_IMPORT_MAIN_CHANNEL, task->state))) {
+        connShutdown(task->main_channel_conn); /* Simulate a failure */
         return;
     }
 
@@ -916,7 +1160,7 @@ void clusterSyncSlotsSnapshotEOF(client *c) {
  * that the slot sync stream has ended and the slots can be handed off. */
 void clusterSyncSlotsStreamEOF(client *c) {
     asmTask *task = c->task;
-    if (task->state != ASM_STREAMING_BUF && task->state != ASM_WAIT_STREAM_EOF) {
+    if (task->state != ASM_WAIT_STREAM_EOF) {
         serverLog(LL_WARNING, "Unexpected CLUSTER SYNCSLOTS STREAM-EOF state: %s",
                                asmTaskStateToString(task->state));
         return;
@@ -937,6 +1181,15 @@ void clusterSyncSlotsStreamEOF(client *c) {
 void asmStartSyncSlots(asmTask *task) {
     if (task->operation != ASM_IMPORT || task->state != ASM_NONE) return;
 
+    /* TODO: async clean up slots data, and propagate to replica */
+    for (int i = 0; i < task->slot_ranges->num_ranges; i++) {
+        slotRange *sr = &task->slot_ranges->ranges[i];
+        for (int j = sr->start; j <= sr->end; j++) {
+            /* Clear the slot data */
+            delKeysInSlot(j);
+        }
+    }
+
     task->start_time = server.mstime;
 
     /* TODO: tls support tests */
@@ -947,6 +1200,8 @@ void asmStartSyncSlots(asmTask *task) {
     {
         serverLog(LL_WARNING,"Unable to connect to source node: %s",
                     connGetLastError(task->main_channel_conn));
+        asmTaskSetError(task, "Import main channel failed to connect to source node: %s",
+                        connGetLastError(task->main_channel_conn));
         asmImportFailed(task);
         return;
     }
@@ -1035,6 +1290,13 @@ void clusterSyncSlotsCommand(client *c) {
             return;
         }
 
+        if (task->main_channel_client == NULL) {
+            /* The main channel connection is closed. */
+            addReplyError(c, "Main channel connection is not established");
+            return;
+        }
+
+        /* Mark the client as a slave */
         c->flags |= (CLIENT_SLAVE | CLIENT_REPL_RDB_CHANNEL | CLIENT_REPL_RDBONLY);
         c->slave_capa |= SLAVE_CAPA_EOF;
         c->slave_req |= (SLAVE_REQ_SLOTS_SNAPSHOT | SLAVE_REQ_RDB_CHANNEL);
@@ -1045,17 +1307,13 @@ void clusterSyncSlotsCommand(client *c) {
         listAddNodeTail(server.slaves, c);
         /* Create the replication backlog if needed. */
         createReplicationBacklogIfNeeded();
-        c->main_ch_client_id = task->main_channel_id;
         c->task = task;
-
-        /* Add main channel client to the list of slaves */
-        client *main_ch_client = task->main_channel_client;
-        main_ch_client->flags |= (CLIENT_SLAVE | CLIENT_REPL_MIGRATION_DEST);
-        main_ch_client->replstate = SLAVE_STATE_WAIT_RDB_CHANNEL;
-        listAddNodeTail(server.slaves, main_ch_client);
 
         /* Wait for bgsave to start for slots sync */
         task->state = ASM_WAIT_BGSAVE_START;
+        task->rdb_channel_client = c;
+        /* The main channel client must be present when setting RDB channel client */
+        serverAssert(task->main_channel_client != NULL);
 
         if (!hasActiveChildProcess()) {
             startBgsaveForReplication(c->slave_capa, c->slave_req);
@@ -1085,8 +1343,8 @@ void clusterSyncSlotsCommand(client *c) {
                     return;
                 }
                 task->source_offset = offset;
-                serverLog(LL_NOTICE, "CLUSTER SYNCSLOTS ACK received, offset: %lld, updated source offset to %lld",
-                          offset, task->source_offset);
+                serverLog(LL_NOTICE, "CLUSTER SYNCSLOTS ACK received, offset: %lld, updated source offset to %lld, destination offset: %lld",
+                          offset, task->source_offset, task->dest_offset);
             }
         } else if (c->task && c->task->operation == ASM_MIGRATE) {
             /* Update the ACKed offset from destination. */
@@ -1097,14 +1355,18 @@ void clusterSyncSlotsCommand(client *c) {
                 return;
             }
             task->dest_offset = offset;
-            serverLog(LL_NOTICE, "CLUSTER SYNCSLOTS ACK received, offset: %lld, updated destination offset to %lld",
-                    offset, task->dest_offset);
+            serverLog(LL_NOTICE, "CLUSTER SYNCSLOTS ACK received, offset: %lld, updated destination offset to %lld, source offset: %lld",
+                    offset, task->dest_offset, task->source_offset);
 
             /* Pause write if needed */
-            task->state = ASM_WAIT_PAUSE_WRITE;
-            task->main_channel_client = c;
-
-            clusterAsmOnEvent(task->slot_ranges, ASM_EVENT_MIGRATE_WAIT_PAUSE, NULL);
+            if (task->state == ASM_SEND_BULK_AND_STREAM) {
+                /* Pause the write on the main channel connection if the gap is less
+                 * than the desired threshold. */
+                if (task->dest_offset + ASM_PAUSE_WRITE_MAX_GAP_BYTES >= task->source_offset) {
+                    task->state = ASM_WAIT_PAUSE_WRITE;
+                    clusterAsmOnEvent(task->slot_ranges, ASM_EVENT_MIGRATE_WAIT_PAUSE, NULL);
+                }
+            }
         }
     } else if (!strcasecmp(c->argv[2]->ptr, "fail") && c->argc == 4) {
         /* CLUSTER SYNCSLOTS FAIL <err> */
@@ -1233,7 +1495,8 @@ static void asmReadSyncBufferErrorHandler(connection *conn) {
     serverLog(LL_WARNING, "ASM buffer stream: error while reading from source: %s",
               connGetLastError(conn));
     asmTask *task = connGetPrivateData(conn);
-
+    asmTaskSetError(task, "Import main channel buffer stream read error: %s, state: %s",
+                          connGetLastError(conn), asmTaskStateToString(task->state));
     asmImportFailed(task);
 }
 
@@ -1266,6 +1529,11 @@ static int asmSyncBufferStreamShouldContinue(void *ctx) {
     replDataBufToDbCtx *context = ctx;
     client *c = context->client;
     asmTask *task = c->task;
+
+    if (unlikely(asmIsFailPointActive(ASM_IMPORT_MAIN_CHANNEL, task->state))) {
+        /* Since the client is protected, freeClient will become async */
+        freeClient(c);
+    }
 
     /* Check if the client is still valid, maybe killed by `client kill`,
      * or the task is no longer in the streaming state, maybe the task is
@@ -1304,31 +1572,37 @@ void asmSyncBufferStreamToDb(asmTask *task) {
     unprotectClient(c);
 
     if (ret == C_OK) {
-        /* ACK offset during streaming buffer. */
-        sds offset = sdsfromlonglong(ctx.total_offset);
-        char *err = sendCommand(task->main_channel_conn, "CLUSTER", "SYNCSLOTS", "ACK", offset, NULL);
-        sdsfree(offset);
-        if (err == NULL) {
-            /* Wait STREAM-EOF from the source node. */
-            task->state = ASM_WAIT_STREAM_EOF;
-            connSetReadHandler(task->main_channel_conn, readQueryFromClient);
-            serverLog(LL_NOTICE, "Streaming buffer for task is done, size: %zu", ctx.total_offset);
-            return;
-        }
-        serverLog(LL_WARNING, "Error sending CLUSTER SYNCSLOTS ACK: %s", err);
-        sdsfree(err);
+        /* Update the dest offset according to applied bytes. */
+        task->dest_offset = ctx.total_offset;
+        /* Wait STREAM-EOF from the source node. */
+        task->state = ASM_WAIT_STREAM_EOF;
+        connSetReadHandler(task->main_channel_conn, readQueryFromClient);
+        serverLog(LL_NOTICE, "Streaming buffer for task is done, size: %lld", task->dest_offset);
+        if (unlikely(asmIsFailPointActive(ASM_IMPORT_MAIN_CHANNEL, task->state)))
+            connShutdown(task->main_channel_conn); /* Simulate a failure */
+
+        /* ACK offset after streaming buffer is done. */
+        asmImportSendACK(task);
     } else {
+        /* If the streaming buffer failed, we need to clean up the task and
+         * the main channel connection, to avoid client exposure not in
+         * ASM_WAIT_STREAM_EOF state */
+        // task->main_channel_conn = NULL;
+        // c->task = NULL;
+        // c->flags &= ~CLIENT_MASTER;
+        // freeClientAsync(c);
+    
         serverLog(LL_WARNING, "Streaming buffer for task failed");
+        asmTaskSetError(task, "Import main channel streaming to DB failed, state: %s",
+                              asmTaskStateToString(task->state));
+        asmImportFailed(task);
     }
+}
 
-    /* Free the main channel connection. */
-    task->main_channel_conn = NULL;
-    c->task = NULL;
-    c->flags &= ~CLIENT_MASTER;
-    freeClientAsync(c);
-
-    /* The task is failed. */
-    asmImportFailed(task);
+void asmImportIncrAppliedBytes(struct asmTask *task, size_t bytes) {
+    if (!task || task->state != ASM_WAIT_STREAM_EOF) return;
+    serverAssert(task->operation == ASM_IMPORT);
+    task->dest_offset += bytes;
 }
 
 void asmBeforeSleep(void) {
@@ -1341,11 +1615,65 @@ void asmBeforeSleep(void) {
             asmStartSyncSlots(task);
         } else if (task->state == ASM_STREAMING_BUF) {
             asmSyncBufferStreamToDb(task);
+        }
+    }
+
+    if (task->operation == ASM_MIGRATE) {
+        if (task->state == ASM_PAUSED_WRITE) {
+            client *c = task->main_channel_client;
+            /* All slot ranges command stream drained */
+            if (!clientHasPendingReplies(c)) {
+                /* Send STREAM EOF, must use this approach to guarantee this command delivery */
+                char *err = sendCommand(c->conn, "CLUSTER", "SYNCSLOTS", "STREAM-EOF", NULL);
+                if (err) {
+                    serverLog(LL_WARNING, "Error sending CLUSTER SYNCSLOTS STREAM-EOF: %s", err);
+                    asmTaskSetError(task, "Migrate main channel sending STREAM-EOF failed: %s, state: %s",
+                                          err, asmTaskStateToString(task->state));
+                    asmMigrateFailed(task);
+                    sdsfree(err);
+                    return;
+                }
+
+                /* Free clients since they are no longer needed */
+                asmMigrateCloseClients(task);
+
+                task->state = ASM_STREAM_DONE;
+                /* Notify plugin import is completed */
+                clusterAsmOnEvent(task->slot_ranges, ASM_EVENT_MIGRATE_WAIT_FINALIZE, NULL);
+            }
         } else if (task->state == ASM_FAILED) {
-            asmTaskReset(task);
-            task->retry_count++;
-            serverAssert(task->state == ASM_NONE);
-            asmStartSyncSlots(task);
+            task->done_time = server.mstime; /* Don't retry */
+
+            /* TODO: if it is necessary to save this task? As the destination side will retry,
+             * there may be a lots of failed tasks. */
+            /* Move task to done list, for migrate task, the source side doesn't retry,
+             * the destination side does or cancels. */
+            listNode *ln = listFirst(asmManager->tasks);
+            listUnlinkNode(asmManager->tasks, ln);
+            listLinkNodeHead(asmManager->done_tasks, ln);
+            asmManager->total_done_tasks++;
+        }
+    }
+}
+
+void asmCron(void) {
+    static long long asm_cron_runs = 0;
+    asm_cron_runs++;
+
+    if (listLength(asmManager->tasks) == 0) return;
+    asmTask *task = listNodeValue(listFirst(asmManager->tasks));
+
+    if (task->operation == ASM_IMPORT) {
+        if (task->state == ASM_FAILED) {
+            /* Retry every 1 second */
+            if (asm_cron_runs % 10 == 0) {
+                asmTaskReset(task);
+                task->retry_count++;
+                serverAssert(task->state == ASM_NONE);
+                asmStartSyncSlots(task);
+            }
+        } else if (task->state == ASM_WAIT_STREAM_EOF) {
+            asmImportSendACK(task);
         }
     }
 }
@@ -1379,19 +1707,10 @@ int clusterAsmSlotWritesPaused(slotRangeArray *slot_ranges, sds *err) {
     UNUSED(err);
     /* find task matching slot ranges */
     asmTask *task = listNodeValue(listFirst(asmManager->tasks));
-    client *c = task->main_channel_client;
+    if (!task || task->state != ASM_WAIT_PAUSE_WRITE) return C_ERR;
 
     task->state = ASM_PAUSED_WRITE;
-    task->paused_time = mstime();
-
-    /* Drain all slot ranges command stream */
-    /* Send STREAM EOF */
-    sendCommand(c->conn, "CLUSTER", "SYNCSLOTS", "STREAM-EOF", NULL);
-
-    task->state = ASM_STREAM_DONE;
-
-    /* Notify plugin import is completed */
-    clusterAsmOnEvent(task->slot_ranges, ASM_EVENT_MIGRATE_WAIT_FINALIZE, NULL);
+    task->paused_time = server.mstime;
 
     return C_OK;
 }

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -15,7 +15,7 @@
 #define ASM_IMPORT  (1 << 1)
 #define ASM_MIGRATE (1 << 2)
 
-#define ASM_PAUSE_WRITE_MAX_GAP_BYTES (1024 * 1024) /* 1MB, TODO: a new config */
+#define ASM_PAUSE_WRITE_MAX_GAP_BYTES (1 * 1024 * 1024) /* 1MB, TODO: a new config */
 
 typedef struct asmTask {
     int operation;                      /* Either ASM_IMPORT or ASM_MIGRATE */
@@ -47,9 +47,9 @@ struct asmManager {
     size_t sync_buffer_peak;      /* Peak size of sync buffer */
     long long total_done_tasks;   /* Total number of completed tasks */
 
-    /* Fail point injection */
-    int failed_channel;           /* Channel in which the task failed */
-    int failed_state;             /* State in which the task failed */
+    /* Fail point injection for debugging */
+    int debug_failed_channel;     /* Channel in which the task failed */
+    int debug_failed_state;       /* State in which the task failed */
 };
 
 enum asmState {
@@ -114,8 +114,8 @@ void clusterAsmInit(void) {
     asmManager->done_tasks = listCreate();
     asmManager->sync_buffer_peak = 0;
     asmManager->total_done_tasks = 0;
-    asmManager->failed_channel = 0;
-    asmManager->failed_state = 0;
+    asmManager->debug_failed_channel = 0;
+    asmManager->debug_failed_state = 0;
 }
 
 char *asmTaskStateToString(int state) {
@@ -157,38 +157,38 @@ char *asmTaskStateToString(int state) {
     return NULL; /* Unreachable */
 }
 
-int asmTaskSetFailPoint(sds channel, sds state) {
+int asmDebugSetFailPoint(char * channel, char *state) {
     if (!asmManager) {
         serverLog(LL_WARNING, "ASM manager is not initialized");
         return C_ERR;
     }
-    asmManager->failed_channel = 0;
-    asmManager->failed_state = 0;
+    asmManager->debug_failed_channel = 0;
+    asmManager->debug_failed_state = 0;
     if (!channel && !state) return C_ERR;
     if (sdslen(channel) == 0 && sdslen(state) == 0) {
         serverLog(LL_WARNING, "ASM fail point is cleared");
         return C_OK;
     }
 
-    if (!strcasecmp(channel, "import-main-channel")) asmManager->failed_channel = ASM_IMPORT_MAIN_CHANNEL;
-    else if (!strcasecmp(channel, "import-rdb-channel")) asmManager->failed_channel = ASM_IMPORT_RDB_CHANNEL;
-    else if (!strcasecmp(channel, "migrate-main-channel")) asmManager->failed_channel = ASM_MIGRATE_MAIN_CHANNEL;
-    else if (!strcasecmp(channel, "migrate-rdb-channel")) asmManager->failed_channel = ASM_MIGRATE_RDB_CHANNEL;
+    if (!strcasecmp(channel, "import-main-channel")) asmManager->debug_failed_channel = ASM_IMPORT_MAIN_CHANNEL;
+    else if (!strcasecmp(channel, "import-rdb-channel")) asmManager->debug_failed_channel = ASM_IMPORT_RDB_CHANNEL;
+    else if (!strcasecmp(channel, "migrate-main-channel")) asmManager->debug_failed_channel = ASM_MIGRATE_MAIN_CHANNEL;
+    else if (!strcasecmp(channel, "migrate-rdb-channel")) asmManager->debug_failed_channel = ASM_MIGRATE_RDB_CHANNEL;
     else return C_ERR;
 
-    if (!strcasecmp(state, "connecting")) asmManager->failed_state = ASM_CONNECTING;
-    else if (!strcasecmp(state, "auth-reply")) asmManager->failed_state = ASM_AUTH_REPLY;
-    else if (!strcasecmp(state, "handshake-reply")) asmManager->failed_state = ASM_HANDSHAKE_REPLY;
-    else if (!strcasecmp(state, "syncslots-reply")) asmManager->failed_state = ASM_SYNCSLOTS_REPLY;
-    else if (!strcasecmp(state, "accumulate-buffer")) asmManager->failed_state = ASM_ACCUMULATE_BUF;
-    else if (!strcasecmp(state, "streaming-buffer")) asmManager->failed_state = ASM_STREAMING_BUF;
-    else if (!strcasecmp(state, "wait-stream-eof")) asmManager->failed_state = ASM_WAIT_STREAM_EOF;
-    else if (!strcasecmp(state, "wait-rdbchannel")) asmManager->failed_state = ASM_WAIT_RDBCHANNEL;
-    else if (!strcasecmp(state, "wait-bgsave-start")) asmManager->failed_state = ASM_WAIT_BGSAVE_START;
-    else if (!strcasecmp(state, "send-bulk-and-stream")) asmManager->failed_state = ASM_SEND_BULK_AND_STREAM;
-    else if (!strcasecmp(state, "paused-write")) asmManager->failed_state = ASM_PAUSED_WRITE;
-    else if (!strcasecmp(state, "rdbchannel-reply")) asmManager->failed_state = ASM_RDBCHANNEL_REPLY;
-    else if (!strcasecmp(state, "rdbchannel-transfer")) asmManager->failed_state = ASM_RDBCHANNEL_TRANSFER;
+    if (!strcasecmp(state, "connecting")) asmManager->debug_failed_state = ASM_CONNECTING;
+    else if (!strcasecmp(state, "auth-reply")) asmManager->debug_failed_state = ASM_AUTH_REPLY;
+    else if (!strcasecmp(state, "handshake-reply")) asmManager->debug_failed_state = ASM_HANDSHAKE_REPLY;
+    else if (!strcasecmp(state, "syncslots-reply")) asmManager->debug_failed_state = ASM_SYNCSLOTS_REPLY;
+    else if (!strcasecmp(state, "accumulate-buffer")) asmManager->debug_failed_state = ASM_ACCUMULATE_BUF;
+    else if (!strcasecmp(state, "streaming-buffer")) asmManager->debug_failed_state = ASM_STREAMING_BUF;
+    else if (!strcasecmp(state, "wait-stream-eof")) asmManager->debug_failed_state = ASM_WAIT_STREAM_EOF;
+    else if (!strcasecmp(state, "wait-rdbchannel")) asmManager->debug_failed_state = ASM_WAIT_RDBCHANNEL;
+    else if (!strcasecmp(state, "wait-bgsave-start")) asmManager->debug_failed_state = ASM_WAIT_BGSAVE_START;
+    else if (!strcasecmp(state, "send-bulk-and-stream")) asmManager->debug_failed_state = ASM_SEND_BULK_AND_STREAM;
+    else if (!strcasecmp(state, "paused-write")) asmManager->debug_failed_state = ASM_PAUSED_WRITE;
+    else if (!strcasecmp(state, "rdbchannel-reply")) asmManager->debug_failed_state = ASM_RDBCHANNEL_REPLY;
+    else if (!strcasecmp(state, "rdbchannel-transfer")) asmManager->debug_failed_state = ASM_RDBCHANNEL_TRANSFER;
     else return C_ERR;
 
     serverLog(LL_NOTICE, "ASM fail point set: channel=%s, state=%s", channel, state);
@@ -205,9 +205,9 @@ const char *asmChannelToString(int channel) {
     }
 }
 
-int asmIsFailPointActive(int channel, int state) {
+int asmDebugIsFailPointActive(int channel, int state) {
     if (!asmManager) return 0; /* No ASM manager initialized */
-    if (asmManager->failed_channel == channel && asmManager->failed_state == state) {
+    if (asmManager->debug_failed_channel == channel && asmManager->debug_failed_state == state) {
         serverLog(LL_NOTICE, "ASM fail point active: channel=%s, state=%s",
                   asmChannelToString(channel), asmTaskStateToString(state));
         return 1;
@@ -226,6 +226,8 @@ void asmTaskReset(asmTask *task) {
     replDataBufInit(&task->sync_buffer);
     sdsfree(task->error);
     task->error = sdsempty();
+    task->main_channel_client = NULL;
+    task->rdb_channel_client = NULL;
 }
 
 asmTask *asmTaskCreate(void) {
@@ -234,7 +236,6 @@ asmTask *asmTaskCreate(void) {
     asmTaskReset(task);
     task->slot_ranges = NULL;
     task->source_node = NULL;
-    task->main_channel_client = NULL;
     task->retry_count = 0;
     task->create_time = server.mstime;
     task->start_time = 0;
@@ -440,7 +441,7 @@ void asmFeedMigrationClient(robj **argv, int argc) {
         return;
     }
 
-    if (unlikely(asmIsFailPointActive(ASM_MIGRATE_MAIN_CHANNEL, task->state)))
+    if (unlikely(asmDebugIsFailPointActive(ASM_MIGRATE_MAIN_CHANNEL, task->state)))
         freeClientAsync(task->main_channel_client);
 
     /* Feed main channel with the command. */
@@ -584,7 +585,7 @@ static void clusterMigrationCommandCancel(client *c) {
 static void replyTaskStatus(client *c, asmTask *task) {
     mstime_t p = 0;
 
-    addReplyMapLen(c, 7);
+    addReplyMapLen(c, 8);
     addReplyBulkCString(c, "slots_range");
     addReplyBulkSds(c, createSlotRangesStr(task->slot_ranges));
     addReplyBulkCString(c, "source");
@@ -597,6 +598,8 @@ static void replyTaskStatus(client *c, asmTask *task) {
     addReplyBulkCString(c, asmTaskStateToString(task->state));
     addReplyBulkCString(c, "error");
     addReplyBulkCBuffer(c, task->error, sdslen(task->error));
+    addReplyBulkCString(c, "retries");
+    addReplyBulkLongLong(c, task->retry_count);
 
     if (task->operation == ASM_MIGRATE && task->state == ASM_DONE)
         p = task->done_time - task->paused_time;
@@ -711,6 +714,10 @@ void asmMigrateFailed(asmTask *task) {
               task->source, task->dest, slot_ranges_str);
     sdsfree(slot_ranges_str);
 
+    /* Actually it is not necessary to clear the sync buffer here,
+     * to make asmTaskReset work properly after migrate task failed  */
+    replDataBufClear(&task->sync_buffer);
+
     /* Mark the task as failed and notify the cluster */
     task->state = ASM_FAILED;
     clusterAsmOnEvent(task->slot_ranges, ASM_EVENT_MIGRATE_FAILED, NULL);
@@ -757,7 +764,7 @@ void asmCallbackOnFreeClient(client *c) {
      * and clean up the RDB channel client if it exists. */
     if (c == task->main_channel_client) {
         task->main_channel_client = NULL;
-        asmTaskSetError(task, "Migrate main and rdb channel client is closed, state: %s",
+        asmTaskSetError(task, "Migrate main and rdb channel client are closed, state: %s",
                               asmTaskStateToString(task->state));
         asmMigrateFailed(task); /* The rdb channel client will be cleaned up */
         return;
@@ -794,8 +801,8 @@ void asmRdbChannelSyncWithSource(connection *conn) {
     }
 
     /* Check if the task is in a fail point state */
-    if (unlikely(asmIsFailPointActive(ASM_IMPORT_RDB_CHANNEL, task->rdb_channel_state))) {
-        char *buf[1];
+    if (unlikely(asmDebugIsFailPointActive(ASM_IMPORT_RDB_CHANNEL, task->rdb_channel_state))) {
+        char buf[1];
         /* Simulate a failure by shutting down the connection. On some operating systems
          * (e.g. Linux), the socket’s receive buffer is not flushed immediately, so we
          * issue a dummy read to drain any pending data and surface the error condition. */
@@ -947,8 +954,8 @@ void asmSyncWithSource(connection *conn) {
     }
 
     /* Check if the fail point is active for this channel and state */
-    if (unlikely(asmIsFailPointActive(ASM_IMPORT_MAIN_CHANNEL, task->state))) {
-        char *buf[1];
+    if (unlikely(asmDebugIsFailPointActive(ASM_IMPORT_MAIN_CHANNEL, task->state))) {
+        char buf[1];
         /* Simulate a failure by shutting down the connection. On some operating systems
          * (e.g. Linux), the socket’s receive buffer is not flushed immediately, so we
          * issue a dummy read to drain any pending data and surface the error condition. */
@@ -1116,7 +1123,7 @@ void asmImportSendACK(asmTask *task) {
 void asmStartSendBulkAndStream(struct asmTask *task) {
     serverAssert(task->state == ASM_WAIT_BGSAVE_START);
 
-    if (unlikely(asmIsFailPointActive(ASM_MIGRATE_RDB_CHANNEL, task->state))) {
+    if (unlikely(asmDebugIsFailPointActive(ASM_MIGRATE_RDB_CHANNEL, task->state))) {
         connShutdown(task->rdb_channel_client->conn);
         return;
     }
@@ -1143,13 +1150,12 @@ void clusterSyncSlotsSnapshotEOF(client *c) {
     }
 
     /* RDB channel state: ASM_RDBCHANNEL_TRANSFER */
-    if (unlikely(asmIsFailPointActive(ASM_IMPORT_RDB_CHANNEL, task->rdb_channel_state))) {
+    if (unlikely(asmDebugIsFailPointActive(ASM_IMPORT_RDB_CHANNEL, task->rdb_channel_state))) {
         freeClientAsync(c); /* Simulate a failure */
         return;
     }
     /* Main channel state: ASM_ACCUMULATE_BUF */
-    serverAssert(task->state == ASM_ACCUMULATE_BUF);
-    if (unlikely(asmIsFailPointActive(ASM_IMPORT_MAIN_CHANNEL, task->state))) {
+    if (unlikely(asmDebugIsFailPointActive(ASM_IMPORT_MAIN_CHANNEL, task->state))) {
         connShutdown(task->main_channel_conn); /* Simulate a failure */
         return;
     }
@@ -1249,33 +1255,46 @@ void clusterSyncSlotsCommand(client *c) {
             return;
         }
 
-        /* Only one slots sync on source node */
-        if (listLength(asmManager->tasks) != 0) {
+        asmTask *task = listLength(asmManager->tasks) == 0 ? NULL :
+                            listNodeValue(listFirst(asmManager->tasks));
+        if (task && task->operation == ASM_MIGRATE && task->state == ASM_FAILED &&
+            slotRangeArrayIsEqual(slot_ranges, task->slot_ranges) &&
+            memcmp(task->dest, c->node_id, CLUSTER_NAMELEN) == 0)
+        {
+            /* Reuse the failed task */
+            asmTaskReset(task);
+            zfree(task->slot_ranges); /* Will be set again later */
+            task->retry_count++;
+        } else if (task) {
             addReplyError(c, "SYNCSLOTS RANGES already in progress");
             zfree(slot_ranges);
             return;
         }
 
-        /* Create the migrate slots task */
-        asmTask *task = asmTaskCreate();
+        /* Create the migrate slots task and add it to the list,
+         * otherwise reuse the existing one */
+        if (task == NULL) {
+            task = asmTaskCreate();
+            task->start_time = server.mstime; /* Start immediately */
+            listAddNodeTail(asmManager->tasks, task);
+        }
+
         task->slot_ranges = slot_ranges;
         task->main_channel_id = c->id;
         task->operation = ASM_MIGRATE;
         memcpy(task->source, getMyClusterNode()->name, CLUSTER_NAMELEN);
         if (c->node_id) memcpy(task->dest, c->node_id, CLUSTER_NAMELEN);
-        c->task = task;
 
         clusterNode *dst = clusterLookupNode(task->dest, CLUSTER_NAMELEN);
         if (dst) {
             int port = server.tls_replication ? dst->tls_port : dst->tcp_port;
             c->slave_listening_port = port;
         }
-        /* Add the task to the list of active tasks */
-        listAddNodeTail(asmManager->tasks, task);
+
+        task->main_channel_client = c;
+        c->task = task;
 
         /* Wait for RDB channel to be ready */
-        task->main_channel_client = c;
-        task->start_time = server.mstime;
         task->state = ASM_WAIT_RDBCHANNEL;
 
         clusterAsmOnEvent(task->slot_ranges, ASM_EVENT_MIGRATE_STARTED, NULL);
@@ -1307,7 +1326,7 @@ void clusterSyncSlotsCommand(client *c) {
             return;
         }
 
-        if (unlikely(asmIsFailPointActive(ASM_MIGRATE_MAIN_CHANNEL, task->state))) {
+        if (unlikely(asmDebugIsFailPointActive(ASM_MIGRATE_MAIN_CHANNEL, task->state))) {
             /* Close the main channel client before establishing rdb channel client */
             if (task->main_channel_client)
                 freeClient(task->main_channel_client);
@@ -1320,7 +1339,7 @@ void clusterSyncSlotsCommand(client *c) {
         }
 
         /* Mark the client as a slave */
-        c->flags |= (CLIENT_SLAVE | CLIENT_REPL_RDB_CHANNEL | CLIENT_REPL_RDBONLY);
+        c->flags |= (CLIENT_SLAVE | CLIENT_REPL_RDB_CHANNEL | CLIENT_REPL_RDBONLY | CLIENT_REPL_MIGRATION_DEST);
         c->slave_capa |= SLAVE_CAPA_EOF;
         c->slave_req |= (SLAVE_REQ_SLOTS_SNAPSHOT | SLAVE_REQ_RDB_CHANNEL);
         c->replstate = SLAVE_STATE_WAIT_BGSAVE_START;
@@ -1330,11 +1349,12 @@ void clusterSyncSlotsCommand(client *c) {
         listAddNodeTail(server.slaves, c);
         /* Create the replication backlog if needed. */
         createReplicationBacklogIfNeeded();
-        c->task = task;
 
         /* Wait for bgsave to start for slots sync */
         task->state = ASM_WAIT_BGSAVE_START;
         task->rdb_channel_client = c;
+        c->task = task;
+
         /* The main channel client must be present when setting RDB channel client */
         serverAssert(task->main_channel_client != NULL);
 
@@ -1366,8 +1386,8 @@ void clusterSyncSlotsCommand(client *c) {
                     return;
                 }
                 task->source_offset = offset;
-                serverLog(LL_NOTICE, "CLUSTER SYNCSLOTS ACK received, offset: %lld, updated source offset to %lld, destination offset: %lld",
-                          offset, task->source_offset, task->dest_offset);
+                serverLog(LL_NOTICE, "CLUSTER SYNCSLOTS ACK received, updated source offset to %lld, destination offset: %lld",
+                                     task->source_offset, task->dest_offset);
             }
         } else if (c->task && c->task->operation == ASM_MIGRATE) {
             /* Update the ACKed offset from destination. */
@@ -1378,8 +1398,8 @@ void clusterSyncSlotsCommand(client *c) {
                 return;
             }
             task->dest_offset = offset;
-            serverLog(LL_NOTICE, "CLUSTER SYNCSLOTS ACK received, offset: %lld, updated destination offset to %lld, source offset: %lld",
-                    offset, task->dest_offset, task->source_offset);
+            serverLog(LL_NOTICE, "CLUSTER SYNCSLOTS ACK received, updated destination offset to %lld, source offset: %lld",
+                                 task->dest_offset, task->source_offset);
 
             /* Pause write if needed */
             if (task->state == ASM_SEND_BULK_AND_STREAM) {
@@ -1440,7 +1460,7 @@ int slotRangesSnapshotSaveRio(int req, rio *rdb, int *error) {
     dictEntry *de;
     kvstoreDictIterator *kvs_di = NULL;
 
-    if (unlikely(asmIsFailPointActive(ASM_MIGRATE_RDB_CHANNEL, ASM_SEND_BULK_AND_STREAM)))
+    if (unlikely(asmDebugIsFailPointActive(ASM_MIGRATE_RDB_CHANNEL, ASM_SEND_BULK_AND_STREAM)))
         rioAbort(rdb); /* Simulate a failure */
 
     for (int i = 0; i < server.dbnum; i++) {
@@ -1557,7 +1577,7 @@ static int asmSyncBufferStreamShouldContinue(void *ctx) {
     client *c = context->client;
     asmTask *task = c->task;
 
-    if (unlikely(asmIsFailPointActive(ASM_IMPORT_MAIN_CHANNEL, task->state))) {
+    if (unlikely(asmDebugIsFailPointActive(ASM_IMPORT_MAIN_CHANNEL, task->state))) {
         /* Since the client is protected, freeClient will become async */
         freeClient(c);
     }
@@ -1607,7 +1627,7 @@ void asmSyncBufferStreamToDb(asmTask *task) {
         serverLog(LL_NOTICE, "Streaming buffer for task is done, applied offset: %lld",
                              task->dest_offset);
 
-        if (unlikely(asmIsFailPointActive(ASM_IMPORT_MAIN_CHANNEL, task->state)))
+        if (unlikely(asmDebugIsFailPointActive(ASM_IMPORT_MAIN_CHANNEL, task->state)))
             connShutdown(task->main_channel_conn); /* Simulate a failure */
 
         /* ACK offset after streaming buffer is done. */
@@ -1654,7 +1674,7 @@ void asmBeforeSleep(void) {
             if (!clientHasPendingReplies(c)) {
                 serverLog(LL_NOTICE, "The command streams for slot ranges have been drained, sending STREAM-EOF");
 
-                if (unlikely(asmIsFailPointActive(ASM_MIGRATE_MAIN_CHANNEL, task->state)))
+                if (unlikely(asmDebugIsFailPointActive(ASM_MIGRATE_MAIN_CHANNEL, task->state)))
                     connShutdown(c->conn);
 
                 /* Send STREAM EOF, must use this approach to guarantee this command delivery */
@@ -1679,17 +1699,6 @@ void asmBeforeSleep(void) {
                 /* Notify plugin import is completed */
                 clusterAsmOnEvent(task->slot_ranges, ASM_EVENT_MIGRATE_WAIT_FINALIZE, NULL);
             }
-        } else if (task->state == ASM_FAILED) {
-            task->done_time = server.mstime; /* Don't retry */
-
-            /* TODO: if it is necessary to save this task? As the destination side will retry,
-             * there may be a lots of failed tasks. */
-            /* Move task to done list, for migrate task, the source side doesn't retry,
-             * the destination side does or cancels. */
-            listNode *ln = listFirst(asmManager->tasks);
-            listUnlinkNode(asmManager->tasks, ln);
-            listLinkNodeHead(asmManager->done_tasks, ln);
-            asmManager->total_done_tasks++;
         }
     }
 }

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -107,7 +107,6 @@ void createDumpPayload(rio *payload, robj *o, robj *key, int dbid);
 int startBgsaveForReplication(int mincapa, int req);
 void createReplicationBacklogIfNeeded(void);
 static void asmSyncBufferReadFromConn(connection *conn);
-unsigned int delKeysInSlot(unsigned int hashslot);
 
 void clusterAsmInit(void) {
     asmManager = zcalloc(sizeof(*asmManager));
@@ -1201,13 +1200,7 @@ void asmStartSyncSlots(asmTask *task) {
     if (task->operation != ASM_IMPORT || task->state != ASM_NONE) return;
 
     /* TODO: async clean up slots data, and propagate to replica */
-    for (int i = 0; i < task->slot_ranges->num_ranges; i++) {
-        slotRange *sr = &task->slot_ranges->ranges[i];
-        for (int j = sr->start; j <= sr->end; j++) {
-            /* Clear the slot data */
-            delKeysInSlot(j);
-        }
-    }
+    clusterDelKeysInSlotRangeArray(task->slot_ranges, CLUSTER_DELKEYS_ASYNC);
 
     task->start_time = server.mstime;
 

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -15,7 +15,7 @@
 #define ASM_IMPORT  (1 << 1)
 #define ASM_MIGRATE (1 << 2)
 
-#define ASM_PAUSE_WRITE_MAX_GAP_BYTES (1024 * 1024) /* 1MB */
+#define ASM_PAUSE_WRITE_MAX_GAP_BYTES (1024 * 1024) /* 1MB, TODO: a new config */
 
 typedef struct asmTask {
     int operation;                      /* Either ASM_IMPORT or ASM_MIGRATE */
@@ -1100,6 +1100,7 @@ write_error: /* Handle sendCommand() errors. */
 
 void asmImportSendACK(asmTask *task) {
     serverAssert(task->operation == ASM_IMPORT && task->state == ASM_WAIT_STREAM_EOF);
+    serverLog(LL_NOTICE, "Destination node applied offset is %lld", task->dest_offset);
 
     sds offset = sdsfromlonglong(task->dest_offset);
     char *err = sendCommand(task->main_channel_conn, "CLUSTER", "SYNCSLOTS", "ACK", offset, NULL);
@@ -1387,6 +1388,8 @@ void clusterSyncSlotsCommand(client *c) {
                 /* Pause the write on the main channel connection if the gap is less
                  * than the desired threshold. */
                 if (task->dest_offset + ASM_PAUSE_WRITE_MAX_GAP_BYTES >= task->source_offset) {
+                    serverLog(LL_NOTICE, "The applied offset gap %lld is less than the threshold %d, pausing write",
+                                         task->source_offset - task->dest_offset, (int)ASM_PAUSE_WRITE_MAX_GAP_BYTES);
                     task->state = ASM_WAIT_PAUSE_WRITE;
                     clusterAsmOnEvent(task->slot_ranges, ASM_EVENT_MIGRATE_WAIT_PAUSE, NULL);
                 }
@@ -1650,6 +1653,7 @@ void asmBeforeSleep(void) {
             client *c = task->main_channel_client;
             /* All slot ranges command stream drained */
             if (!clientHasPendingReplies(c)) {
+                serverLog(LL_NOTICE, "All slot ranges command stream drained, sending STREAM-EOF");
 
                 if (unlikely(asmIsFailPointActive(ASM_MIGRATE_MAIN_CHANNEL, task->state)))
                     connShutdown(c->conn);

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -158,14 +158,15 @@ char *asmTaskStateToString(int state) {
     return NULL; /* Unreachable */
 }
 
-int asmTaskSetFailPoint(const char *channel, const char *state) {
+int asmTaskSetFailPoint(sds channel, sds state) {
     if (!asmManager) {
         serverLog(LL_WARNING, "ASM manager is not initialized");
         return C_ERR;
     }
     asmManager->failed_channel = 0;
     asmManager->failed_state = 0;
-    if (!channel && !state) {
+    if (!channel && !state) return C_ERR;
+    if (sdslen(channel) == 0 && sdslen(state) == 0) {
         serverLog(LL_WARNING, "Fail point is cleared");
         return C_OK;
     }
@@ -186,7 +187,6 @@ int asmTaskSetFailPoint(const char *channel, const char *state) {
     else if (!strcasecmp(state, "wait-rdbchannel")) asmManager->failed_state = ASM_WAIT_RDBCHANNEL;
     else if (!strcasecmp(state, "wait-bgsave-start")) asmManager->failed_state = ASM_WAIT_BGSAVE_START;
     else if (!strcasecmp(state, "send-bulk-and-stream")) asmManager->failed_state = ASM_SEND_BULK_AND_STREAM;
-    else if (!strcasecmp(state, "wait-pause-write")) asmManager->failed_state = ASM_WAIT_PAUSE_WRITE;
     else if (!strcasecmp(state, "paused-write")) asmManager->failed_state = ASM_PAUSED_WRITE;
     else if (!strcasecmp(state, "rdbchannel-reply")) asmManager->failed_state = ASM_RDBCHANNEL_REPLY;
     else if (!strcasecmp(state, "rdbchannel-transfer")) asmManager->failed_state = ASM_RDBCHANNEL_TRANSFER;
@@ -208,10 +208,9 @@ const char *asmChannelToString(int channel) {
 
 int asmIsFailPointActive(int channel, int state) {
     if (!asmManager) return 0; /* No ASM manager initialized */
-    if (asmManager->failed_channel == channel &&
-            asmManager->failed_state == state) {
-        serverLog(LL_NOTICE, "ASM fail point active: channel=%d, state=%d",
-                  channel, state);
+    if (asmManager->failed_channel == channel && asmManager->failed_state == state) {
+        serverLog(LL_NOTICE, "ASM fail point active: channel=%s, state=%s",
+                  asmChannelToString(channel), asmTaskStateToString(state));
         return 1;
     }
     return 0;
@@ -227,7 +226,7 @@ void asmTaskReset(asmTask *task) {
     task->source_offset = 0;
     replDataBufInit(&task->sync_buffer);
     sdsfree(task->error);
-    task->error = sdsempty();    
+    task->error = sdsempty();
 }
 
 asmTask *asmTaskCreate(void) {
@@ -441,6 +440,9 @@ void asmFeedMigrationClient(robj **argv, int argc) {
     {
         return;
     }
+
+    if (unlikely(asmIsFailPointActive(ASM_MIGRATE_MAIN_CHANNEL, task->state)))
+        freeClientAsync(task->main_channel_client);
 
     /* Feed main channel with the command. */
     client *c = task->main_channel_client;
@@ -656,6 +658,7 @@ void asmTaskSetError(asmTask *task, const char *fmt, ...) {
 
 void asmImportFailed(asmTask *task) {
     serverAssert(task->operation == ASM_IMPORT);
+    serverAssert(task->state != ASM_FAILED);
 
     /* If we are in the RDB channel transfer state, we need to
      * close the client that was created for the RDB channel. */
@@ -699,6 +702,7 @@ void asmImportFailed(asmTask *task) {
 
 void asmMigrateFailed(asmTask *task) {
     serverAssert(task->operation == ASM_MIGRATE);
+    serverAssert(task->state != ASM_FAILED);
 
     /* Clients cleanup */
     asmMigrateCloseClients(task);
@@ -747,16 +751,16 @@ void asmCallbackOnFreeClient(client *c) {
          * the destination side will also close the main channel.
          * So here we just reset the RDB channel client of task. */
         task->rdb_channel_client = NULL;
-        c->task = NULL; /* Clear the task reference */
         return;
     }
 
     /* If the main channel client is closed, we need to mark the task as failed
      * and clean up the RDB channel client if it exists. */
     if (c == task->main_channel_client) {
-        asmTaskSetError(task, "Migrate main channel client is closed, state: %s",
+        task->main_channel_client = NULL;
+        asmTaskSetError(task, "Migrate main and rdb channel client is closed, state: %s",
                               asmTaskStateToString(task->state));
-        asmMigrateFailed(task);
+        asmMigrateFailed(task); /* The rdb channel client will be cleaned up */
         return;
     }
 }
@@ -792,8 +796,12 @@ void asmRdbChannelSyncWithSource(connection *conn) {
 
     /* Check if the task is in a fail point state */
     if (unlikely(asmIsFailPointActive(ASM_IMPORT_RDB_CHANNEL, task->rdb_channel_state))) {
-        /* Simulate a failure */
+        char *buf[1];
+        /* Simulate a failure by shutting down the connection. On some operating systems
+         * (e.g. Linux), the socket’s receive buffer is not flushed immediately, so we
+         * issue a dummy read to drain any pending data and surface the error condition. */
         connShutdown(conn);
+        connRead(conn, buf, 1);
     }
 
     if (task->rdb_channel_state == ASM_CONNECTING) {
@@ -941,8 +949,12 @@ void asmSyncWithSource(connection *conn) {
 
     /* Check if the fail point is active for this channel and state */
     if (unlikely(asmIsFailPointActive(ASM_IMPORT_MAIN_CHANNEL, task->state))) {
-        /* Simulate a failure */
+        char *buf[1];
+        /* Simulate a failure by shutting down the connection. On some operating systems
+         * (e.g. Linux), the socket’s receive buffer is not flushed immediately, so we
+         * issue a dummy read to drain any pending data and surface the error condition. */
         connShutdown(conn);
+        connRead(conn, buf, 1);
     }
 
     if (task->state == ASM_CONNECTING) {
@@ -1103,6 +1115,12 @@ void asmImportSendACK(asmTask *task) {
 
 void asmStartSendBulkAndStream(struct asmTask *task) {
     serverAssert(task->state == ASM_WAIT_BGSAVE_START);
+
+    if (unlikely(asmIsFailPointActive(ASM_MIGRATE_RDB_CHANNEL, task->state))) {
+        connShutdown(task->rdb_channel_client->conn);
+        return;
+    }
+
     task->state = ASM_SEND_BULK_AND_STREAM;
 }
 
@@ -1290,7 +1308,13 @@ void clusterSyncSlotsCommand(client *c) {
             return;
         }
 
-        if (task->main_channel_client == NULL) {
+        if (unlikely(asmIsFailPointActive(ASM_MIGRATE_MAIN_CHANNEL, task->state))) {
+            /* Close the main channel client before establishing rdb channel client */
+            if (task->main_channel_client)
+                freeClient(task->main_channel_client);
+        }
+
+        if (task->state != ASM_WAIT_RDBCHANNEL || task->main_channel_client == NULL) {
             /* The main channel connection is closed. */
             addReplyError(c, "Main channel connection is not established");
             return;
@@ -1414,6 +1438,9 @@ int slotRangesSnapshotSaveRio(int req, rio *rdb, int *error) {
 
     dictEntry *de;
     kvstoreDictIterator *kvs_di = NULL;
+
+    if (unlikely(asmIsFailPointActive(ASM_MIGRATE_RDB_CHANNEL, ASM_SEND_BULK_AND_STREAM)))
+        rioAbort(rdb); /* Simulate a failure */
 
     for (int i = 0; i < server.dbnum; i++) {
         char selectcmd[] = "*2\r\n$6\r\nSELECT\r\n";
@@ -1585,13 +1612,13 @@ void asmSyncBufferStreamToDb(asmTask *task) {
         asmImportSendACK(task);
     } else {
         /* If the streaming buffer failed, we need to clean up the task and
-         * the main channel connection, to avoid client exposure not in
+         * the main channel connection, to avoid client exposure when not in
          * ASM_WAIT_STREAM_EOF state */
-        // task->main_channel_conn = NULL;
-        // c->task = NULL;
-        // c->flags &= ~CLIENT_MASTER;
-        // freeClientAsync(c);
-    
+        task->main_channel_conn = NULL;
+        c->task = NULL;
+        c->flags &= ~CLIENT_MASTER;
+        freeClientAsync(c);
+
         serverLog(LL_WARNING, "Streaming buffer for task failed");
         asmTaskSetError(task, "Import main channel streaming to DB failed, state: %s",
                               asmTaskStateToString(task->state));
@@ -1623,6 +1650,10 @@ void asmBeforeSleep(void) {
             client *c = task->main_channel_client;
             /* All slot ranges command stream drained */
             if (!clientHasPendingReplies(c)) {
+
+                if (unlikely(asmIsFailPointActive(ASM_MIGRATE_MAIN_CHANNEL, task->state)))
+                    connShutdown(c->conn);
+
                 /* Send STREAM EOF, must use this approach to guarantee this command delivery */
                 char *err = sendCommand(c->conn, "CLUSTER", "SYNCSLOTS", "STREAM-EOF", NULL);
                 if (err) {

--- a/src/cluster_asm.h
+++ b/src/cluster_asm.h
@@ -14,10 +14,13 @@ struct asmTask;
 
 void clusterAsmInit(void);
 void asmBeforeSleep(void);
+void asmCron(void);
 void asmStartSendBulkAndStream(struct asmTask *task);
 void asmCallbackOnFreeClient(client *c);
 int asmMigrateInProgress(void);
 void asmFeedMigrationClient(robj **argv, int argc);
+int asmTaskSetFailPoint(const char *channel, const char *state);
+void asmImportIncrAppliedBytes(struct asmTask *task, size_t bytes);
 
 void clusterMigrationCommand(client *c);
 void clusterSyncSlotsCommand(client *c);

--- a/src/cluster_asm.h
+++ b/src/cluster_asm.h
@@ -19,7 +19,7 @@ void asmStartSendBulkAndStream(struct asmTask *task);
 void asmCallbackOnFreeClient(client *c);
 int asmMigrateInProgress(void);
 void asmFeedMigrationClient(robj **argv, int argc);
-int asmTaskSetFailPoint(sds channel, sds state);
+int asmDebugSetFailPoint(char * channel, char *state);
 void asmImportIncrAppliedBytes(struct asmTask *task, size_t bytes);
 
 void clusterMigrationCommand(client *c);

--- a/src/cluster_asm.h
+++ b/src/cluster_asm.h
@@ -19,7 +19,7 @@ void asmStartSendBulkAndStream(struct asmTask *task);
 void asmCallbackOnFreeClient(client *c);
 int asmMigrateInProgress(void);
 void asmFeedMigrationClient(robj **argv, int argc);
-int asmTaskSetFailPoint(const char *channel, const char *state);
+int asmTaskSetFailPoint(sds channel, sds state);
 void asmImportIncrAppliedBytes(struct asmTask *task, size_t bytes);
 
 void clusterMigrationCommand(client *c);

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -4910,6 +4910,9 @@ void clusterCron(void) {
 
     if (update_state || server.cluster->state == CLUSTER_FAIL)
         clusterUpdateState();
+
+    /* Atomic slot migration cron */
+    asmCron();
 }
 
 /* This function is called before the event handler returns to sleep for

--- a/src/cluster_plugin.c
+++ b/src/cluster_plugin.c
@@ -136,6 +136,7 @@ void clusterInit(void) {
 }
 
 void clusterCron(void) {
+    /* TODO: asmCron */
     clusterPlugin->clusterCron();
 }
 

--- a/src/debug.c
+++ b/src/debug.c
@@ -500,7 +500,7 @@ void debugCommand(client *c) {
 "MARK-INTERNAL-CLIENT [UNMARK]",
 "    Promote the current connection to an internal connection.",
 "ASM-FAILPOINT <channel> <state>",
-"    Set a fail point for the specified channel and state.",
+"    Set a fail point for the specified channel and state for cluster atomic slot migration.",
 NULL
         };
         addExtendedReplyHelp(c, help, clusterDebugCommandExtendedHelp());
@@ -1101,7 +1101,7 @@ NULL
             return;
         }
     } else if(!strcasecmp(c->argv[1]->ptr,"asm-failpoint") && c->argc == 4) {
-        if (asmTaskSetFailPoint(c->argv[2]->ptr, c->argv[3]->ptr) != C_OK) {
+        if (asmDebugSetFailPoint(c->argv[2]->ptr, c->argv[3]->ptr) != C_OK) {
             addReplyError(c, "Failed to set ASM fail point");
         } else {
             addReply(c, shared.ok);

--- a/src/debug.c
+++ b/src/debug.c
@@ -23,6 +23,7 @@
 #include "cluster.h"
 #include "threads_mngr.h"
 #include "script.h"
+#include "cluster_asm.h"
 
 #include <arpa/inet.h>
 #include <signal.h>
@@ -498,6 +499,8 @@ void debugCommand(client *c) {
 "    Output SHA and content of all scripts or of a specific script with its SHA.",
 "MARK-INTERNAL-CLIENT [UNMARK]",
 "    Promote the current connection to an internal connection.",
+"ASM-FAILPOINT <channel> <state>",
+"    Set a fail point for the specified channel and state.",
 NULL
         };
         addExtendedReplyHelp(c, help, clusterDebugCommandExtendedHelp());
@@ -1096,6 +1099,12 @@ NULL
         } else {
             addReplySubcommandSyntaxError(c);
             return;
+        }
+    } else if(!strcasecmp(c->argv[1]->ptr,"asm-failpoint") && c->argc == 4) {
+        if (asmTaskSetFailPoint(c->argv[2]->ptr, c->argv[3]->ptr) != C_OK) {
+            addReplyError(c, "Failed to set ASM fail point");
+        } else {
+            addReply(c, shared.ok);
         }
     } else if(!handleDebugClusterCommand(c)) {
         addReplySubcommandSyntaxError(c);

--- a/src/networking.c
+++ b/src/networking.c
@@ -1783,7 +1783,7 @@ void freeClient(client *c) {
     }
 
     /* Log link disconnection with slave */
-    if (clientTypeIsSlave(c) && !(c->slave_req & SLAVE_REQ_SLOTS_SNAPSHOT)) {
+    if (clientTypeIsSlave(c)) {
         const char *type = c->flags & CLIENT_REPL_RDB_CHANNEL ? " (rdbchannel)" : "";
         serverLog(LL_NOTICE,"Connection with replica%s %s lost.", type,
             replicationGetSlaveName(c));
@@ -2684,6 +2684,9 @@ void commandProcessed(client *c) {
         if (applied) {
             replicationFeedStreamFromMasterStream(c->querybuf+c->repl_applied,applied);
             c->repl_applied += applied;
+
+            /* Update the atomic slot migration task's applied bytes. */
+            if (c->task) asmImportIncrAppliedBytes(c->task, applied);
         }
     }
 }
@@ -4187,6 +4190,14 @@ size_t getClientOutputBufferMemoryUsage(client *c) {
     }
 }
 
+size_t getNormalClientPendingReplyBytes(client *c) {
+    serverAssert(!(c->flags & CLIENT_SLAVE));
+    if (listLength(c->reply) == 0) return c->bufpos;
+
+    clientReplyBlock *block = listNodeValue(listLast(c->reply));
+    return (c->reply_bytes - block->size + block->used) + c->bufpos;
+}
+
 /* Returns the total client's memory usage.
  * Optionally, if output_buffer_mem_usage is not NULL, it fills it with
  * the client output buffer memory usage portion of the total. */
@@ -4235,10 +4246,14 @@ int getClientType(client *c) {
 }
 
 static inline int clientTypeIsSlave(client *c) {
-    /* Even though MONITOR clients and ASM destination main channels are marked
+    /* Even though MONITOR clients and ASM destination RDB/main channels are marked
      * as replicas, we want the expose them as normal clients. */
-    if (unlikely((c->flags & CLIENT_SLAVE) && !(c->flags & (CLIENT_MONITOR | CLIENT_REPL_MIGRATION_DEST))))
+    if (unlikely((c->flags & CLIENT_SLAVE) &&
+        !(c->flags & (CLIENT_MONITOR | CLIENT_REPL_MIGRATION_DEST))) &&
+        !(c->slave_req & SLAVE_REQ_SLOTS_SNAPSHOT))
+    {
         return 1;
+    }
     return 0;
 }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -4249,8 +4249,7 @@ static inline int clientTypeIsSlave(client *c) {
     /* Even though MONITOR clients and ASM destination RDB/main channels are marked
      * as replicas, we want the expose them as normal clients. */
     if (unlikely((c->flags & CLIENT_SLAVE) &&
-        !(c->flags & (CLIENT_MONITOR | CLIENT_REPL_MIGRATION_DEST))) &&
-        !(c->slave_req & SLAVE_REQ_SLOTS_SNAPSHOT))
+        !(c->flags & (CLIENT_MONITOR | CLIENT_REPL_MIGRATION_DEST))))
     {
         return 1;
     }

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3885,6 +3885,7 @@ int rdbSaveToSlavesSockets(int req, rdbSaveInfo *rsi) {
     pid_t childpid;
     int pipefds[2], rdb_pipe_write = 0, safe_to_exit_pipe = 0;
     int rdb_channel = server.repl_rdb_channel && (req & SLAVE_REQ_RDB_CHANNEL);
+    int slots_req = req & SLAVE_REQ_SLOTS_SNAPSHOT;
 
     if (hasActiveChildProcess()) return C_ERR;
 
@@ -4013,7 +4014,7 @@ int rdbSaveToSlavesSockets(int req, rdbSaveInfo *rsi) {
             }
         } else {
             serverLog(LL_NOTICE, "Background RDB transfer started by pid %ld to %s", (long)childpid,
-                      rdb_channel ? "replica socket" : "parent process pipe");
+                rdb_channel ? (slots_req ? "import node" : "replica socket") : "parent process pipe");
             server.rdb_save_time_start = time(NULL);
             server.rdb_child_type = RDB_CHILD_TYPE_SOCKET;
             if (!rdb_channel) {

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -4014,7 +4014,8 @@ int rdbSaveToSlavesSockets(int req, rdbSaveInfo *rsi) {
             }
         } else {
             serverLog(LL_NOTICE, "Background RDB transfer started by pid %ld to %s", (long)childpid,
-                rdb_channel ? (slots_req ? "import node" : "replica socket") : "parent process pipe");
+                rdb_channel ? (slots_req ? "slot migration destination socket" : "replica socket") :
+                              "parent process pipe");
             server.rdb_save_time_start = time(NULL);
             server.rdb_child_type = RDB_CHILD_TYPE_SOCKET;
             if (!rdb_channel) {

--- a/src/replication.c
+++ b/src/replication.c
@@ -970,7 +970,7 @@ int startBgsaveForReplication(int mincapa, int req) {
 
     int slots_req = req & SLAVE_REQ_SLOTS_SNAPSHOT;
     serverLog(LL_NOTICE,"Starting BGSAVE for SYNC with target: %s%s",
-        socket_target ? (slots_req ? "import node" : "replicas sockets") : "disk",
+        socket_target ? (slots_req ? "slot migration destination socket" : "replicas sockets") : "disk",
         (req & SLAVE_REQ_RDB_CHANNEL) ? " (rdb-channel)" : "");
 
     rdbSaveInfo rsi, *rsiptr;

--- a/src/replication.c
+++ b/src/replication.c
@@ -793,18 +793,6 @@ int replicationSetupSlaveForFullResync(client *slave, long long offset) {
     if (slave->flags & CLIENT_REPL_RDB_CHANNEL &&
         slave->slave_req & SLAVE_REQ_SLOTS_SNAPSHOT)
     {
-        uint64_t id = slave->main_ch_client_id;
-        client *c = lookupClientByID(id);
-        if (c && c->replstate == SLAVE_STATE_WAIT_RDB_CHANNEL) {
-            c->replstate = SLAVE_STATE_SEND_BULK_AND_STREAM;
-            serverLog(LL_NOTICE, "Starting to deliver RDB and slots stream to replica: %s",
-                        replicationGetSlaveName(c));
-        } else {
-            serverLog(LL_WARNING, "Starting to deliver RDB to replica %s"
-                                    " but it has no associated main channel",
-                                    replicationGetSlaveName(slave));
-            /* TODO: error handler: No main channel for slots sync */
-        }
         /* Start to deliver the commands stream on exporting slots. */
         asmStartSendBulkAndStream(slave->task);
 
@@ -980,8 +968,9 @@ int startBgsaveForReplication(int mincapa, int req) {
     /* `SYNC` should have failed with error if we don't support socket and require a filter, assert this here */
     serverAssert(socket_target || !(req & SLAVE_REQ_RDB_MASK));
 
+    int slots_req = req & SLAVE_REQ_SLOTS_SNAPSHOT;
     serverLog(LL_NOTICE,"Starting BGSAVE for SYNC with target: %s%s",
-        socket_target ? "replicas sockets" : "disk",
+        socket_target ? (slots_req ? "import node" : "replicas sockets") : "disk",
         (req & SLAVE_REQ_RDB_CHANNEL) ? " (rdb-channel)" : "");
 
     rdbSaveInfo rsi, *rsiptr;

--- a/src/replication.c
+++ b/src/replication.c
@@ -3870,7 +3870,6 @@ static void rdbChannelBufferReplData(connection *conn) {
 int replDataBufStreamToDb(replDataBuf *buf, replDataBufToDbCtx *ctx) {
     listNode *n;
     int ret = C_OK;
-    size_t offset = 0;
     client *c = ctx->client;
 
     blockingOperationStarts();
@@ -3897,13 +3896,13 @@ int replDataBufStreamToDb(replDataBuf *buf, replDataBufToDbCtx *ctx) {
 
             /* Check if we should yield back to the event loop */
             if (server.loading_process_events_interval_bytes &&
-                ((offset + bytes) / server.loading_process_events_interval_bytes >
-                  offset / server.loading_process_events_interval_bytes))
+                ((ctx->applied_offset + bytes) / server.loading_process_events_interval_bytes >
+                  ctx->applied_offset / server.loading_process_events_interval_bytes))
             {
                 ctx->yield_callback(ctx);
                 processEventsWhileBlocked();
             }
-            offset += bytes;
+            ctx->applied_offset += bytes;
 
             /* Check if we should continue processing */
             if (!ctx->should_continue(ctx)) {
@@ -3923,7 +3922,6 @@ int replDataBufStreamToDb(replDataBuf *buf, replDataBufToDbCtx *ctx) {
     }
     blockingOperationEnds();
 
-    ctx->total_offset = offset;
     return ret;
 }
 
@@ -3980,7 +3978,7 @@ static void rdbChannelStreamReplDataToDb(void) {
 
     replDataBufToDbCtx ctx = {
         .client = c,
-        .total_offset = 0,
+        .applied_offset = 0,
         .should_continue = rdbChannelStreamShouldContinue,
         .yield_callback = rdbChannelStreamYieldCallback,
     };
@@ -3997,7 +3995,7 @@ out:
 
     if (ret == C_OK) {
         serverLog(LL_NOTICE, "MASTER <-> REPLICA sync: Successfully streamed replication buffer into the db (%zu bytes in total)",
-                             ctx.total_offset);
+                             ctx.applied_offset);
         /* Revert the read handler */
         if (!close_asap && connSetReadHandler(c->conn, readQueryFromClient) != C_OK) {
             serverLog(LL_WARNING,

--- a/src/server.h
+++ b/src/server.h
@@ -1480,7 +1480,7 @@ typedef struct __attribute__((aligned(CACHE_LINE_SIZE))) {
 /* Context for streaming replDataBuf to database */
 typedef struct replDataBufToDbCtx {
     client *client;                     /* Client to process commands */
-    size_t total_offset;                /* Total offset processed */
+    size_t applied_offset;              /* Offset applied to the database */
     int  (*should_continue)(void *ctx); /* Check if should continue */
     void (*yield_callback)(void *ctx);  /* Yield to event loop */
 } replDataBufToDbCtx;

--- a/src/server.h
+++ b/src/server.h
@@ -2884,6 +2884,7 @@ void rewriteClientCommandArgument(client *c, int i, robj *newval);
 void replaceClientCommandVector(client *c, int argc, robj **argv);
 void redactClientCommandArgument(client *c, int argc);
 size_t getClientOutputBufferMemoryUsage(client *c);
+size_t getNormalClientPendingReplyBytes(client *c);
 size_t getClientMemoryUsage(client *c, size_t *output_buffer_mem_usage);
 int freeClientsInAsyncFreeQueue(void);
 int closeClientOnOutputBufferLimitReached(client *c, int async);

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -148,5 +148,55 @@ start_cluster 3 3 {tags {external:skip cluster}} {
         # verify changes in replica
         R 3 readonly
         assert_equal [string repeat c 100] [R 3 get $slot101_key]
+
+        R 0 config set rdb-key-save-delay 1000000
+    }
+
+    global send_migration_import_0_100
+    set send_migration_import_0_100 0
+    proc test_destination_node_handshake_failure {channel all_states} {
+        global send_migration_import_0_100
+
+        foreach state $all_states {
+            if {$::verbose} { puts "Testing $channel channel with state: $state"}
+
+            # for streaming-buffer state, we need to set a longer delay to write
+            # incremental data to the main channel
+            if {$state eq "streaming-buffer"} { R 1 config set rdb-key-save-delay 1000000 }
+
+            # Start the slot 0 write load on the R 1
+            if {$::tls} { set port [lindex [R 1 config get tls-port] 1]
+            } else { set port [lindex [R 1 config get port] 1] }
+            set load_handle [start_write_load "127.0.0.1" $port 100 "06S"]
+
+            # Set the fail point for the main channel
+            assert_equal {OK} [R 0 debug asm-failpoint "import-$channel-channel" $state]
+
+            # Migrate slot 0-100 to R 0 if this is the first time,
+            # otherwise, import will retry automatically
+            if {$send_migration_import_0_100 == 0} {
+                assert_equal {OK} [R 0 CLUSTER MIGRATION IMPORT 0 100]
+                set send_migration_import_0_100 1
+            }
+
+            # The task should be failed due to the fail point
+            wait_for_condition 1000 50 {
+                [string match "*$channel channel*${state}*" [migration_status 0 0-100 error]]
+            } else {
+                fail "ASM task did not fail"
+            }
+            R 1 config set rdb-key-save-delay 0
+            stop_write_load $load_handle
+        }
+    }
+
+    test "Destination node main channel basic error-handling tests " {
+        set all_states [list "connecting" "auth-reply" "handshake-reply" "syncslots-reply" "accumulate-buffer" "wait-stream-eof" "streaming-buffer"]
+        test_destination_node_handshake_failure "main" $all_states
+    }
+
+    test "Destination node rdb channel basic error-handling tests" {
+        set all_states [list "connecting" "auth-reply" "rdbchannel-reply" "rdbchannel-transfer"]
+        test_destination_node_handshake_failure "rdb" $all_states
     }
 }

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -154,11 +154,11 @@ start_cluster 3 3 {tags {external:skip cluster}} {
 
     global send_migration_import_0_100
     set send_migration_import_0_100 0
-    proc test_destination_node_handshake_failure {channel all_states} {
+    proc asm_basic_error_handling_test {operation channel all_states} {
         global send_migration_import_0_100
 
         foreach state $all_states {
-            if {$::verbose} { puts "Testing $channel channel with state: $state"}
+            if {$::verbose} { puts "Testing $operation $channel channel with state: $state"}
 
             # for streaming-buffer state, we need to set a longer delay to write
             # incremental data to the main channel
@@ -170,7 +170,15 @@ start_cluster 3 3 {tags {external:skip cluster}} {
             set load_handle [start_write_load "127.0.0.1" $port 100 "06S"]
 
             # Set the fail point for the main channel
-            assert_equal {OK} [R 0 debug asm-failpoint "import-$channel-channel" $state]
+            if {$operation eq "import"} {
+                assert_equal {OK} [R 0 debug asm-failpoint "import-$channel-channel" $state]
+                assert_equal {OK} [R 1 debug asm-failpoint "" ""] ;# Clear migrate node fail point
+            } elseif {$operation eq "migrate"} {
+                assert_equal {OK} [R 0 debug asm-failpoint "" ""] ;# Clear import node fail point
+                assert_equal {OK} [R 1 debug asm-failpoint "migrate-$channel-channel" $state]
+            } else {
+                fail "Unknown operation: $operation"
+            }
 
             # Migrate slot 0-100 to R 0 if this is the first time,
             # otherwise, import will retry automatically
@@ -181,7 +189,8 @@ start_cluster 3 3 {tags {external:skip cluster}} {
 
             # The task should be failed due to the fail point
             wait_for_condition 1000 50 {
-                [string match "*$channel channel*${state}*" [migration_status 0 0-100 error]]
+                [string match "*$channel*${state}*" [migration_status 0 0-100 error]] ||
+                [string match "*$channel*${state}*" [migration_status 1 0-100 error]]
             } else {
                 fail "ASM task did not fail"
             }
@@ -191,12 +200,22 @@ start_cluster 3 3 {tags {external:skip cluster}} {
     }
 
     test "Destination node main channel basic error-handling tests " {
-        set all_states [list "connecting" "auth-reply" "handshake-reply" "syncslots-reply" "accumulate-buffer" "wait-stream-eof" "streaming-buffer"]
-        test_destination_node_handshake_failure "main" $all_states
+        set all_states [list "connecting" "auth-reply" "handshake-reply" "syncslots-reply" "accumulate-buffer" "streaming-buffer" "wait-stream-eof"]
+        asm_basic_error_handling_test "import" "main" $all_states
     }
 
     test "Destination node rdb channel basic error-handling tests" {
         set all_states [list "connecting" "auth-reply" "rdbchannel-reply" "rdbchannel-transfer"]
-        test_destination_node_handshake_failure "rdb" $all_states
+        asm_basic_error_handling_test "import" "rdb" $all_states
+    }
+
+    test "Source node main channel basic error-handling tests " {
+        set all_states [list "wait-rdbchannel" "send-bulk-and-stream" "paused-write"]
+        asm_basic_error_handling_test "migrate" "main" $all_states
+    }
+
+    test "Source node rdb channel basic error-handling tests" {
+        set all_states [list "wait-bgsave-start" "send-bulk-and-stream"]
+        asm_basic_error_handling_test "migrate" "rdb" $all_states
     }
 }

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -192,7 +192,7 @@ start_cluster 3 3 {tags {external:skip cluster}} {
                 [string match "*$channel*${state}*" [migration_status 0 0-100 error]] ||
                 [string match "*$channel*${state}*" [migration_status 1 0-100 error]]
             } else {
-                fail "ASM task did not fail"
+                fail "ASM task did not fail with expected error"
             }
             R 1 config set rdb-key-save-delay 0
             stop_write_load $load_handle
@@ -217,5 +217,38 @@ start_cluster 3 3 {tags {external:skip cluster}} {
     test "Source node rdb channel basic error-handling tests" {
         set all_states [list "wait-bgsave-start" "send-bulk-and-stream"]
         asm_basic_error_handling_test "migrate" "rdb" $all_states
+    }
+
+    test "Migration will be successful after fail points are cleared" {
+        # we set a delay to write incremental data
+        R 1 config set rdb-key-save-delay 1000000
+
+        # Start the slot 0 write load on the R 1
+        if {$::tls} { set port [lindex [R 1 config get tls-port] 1]
+        } else { set port [lindex [R 1 config get port] 1] }
+        set load_handle [start_write_load "127.0.0.1" $port 100 "06S"]
+
+        # Clear all fail points
+        assert_equal {OK} [R 0 debug asm-failpoint "" ""]
+        assert_equal {OK} [R 1 debug asm-failpoint "" ""]
+
+        # Wait for the migration to complete
+        wait_for_condition 1000 50 {
+            [string match {*done*} [migration_status 0 0-100 state]] &&
+            [string match {*done*} [migration_status 1 0-100 state]]
+        } else {
+            fail "ASM task did not complete successfully"
+        }
+
+        stop_write_load $load_handle
+
+        # Verify the data is migrated, slot 0 and 1 should belong to R 1
+        # slot 0 key should be changed by the write load
+        assert_not_equal [string repeat a 100] [R 0 get "06S"]
+        assert_equal [string repeat b 100] [R 0 get "Qi"]
+        # Slave should also get the data
+        after 100
+        R 3 readonly
+        assert_equal [string repeat b 100] [R 3 get "Qi"]
     }
 }


### PR DESCRIPTION
- DEBUG ASM-FAILPOINT <channel> <state> to set fail point
- Error handler for both source and destination side & tcl tests
- Error info for task
- Destination node sends ACK in Cron
- Source node checks applied offset gap and pauses writing
- Source node sends stream-eof after slot commands stream drained in beforeSleep