### PR TITLE
Fix plugin api

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1672,6 +1672,45 @@ int validateSlotRanges(slotRangeArray *sra, sds *err) {
     return C_OK;
 }
 
+/* Create a slot range array with the specified number of ranges. */
+slotRangeArray *slotRangeArrayCreate(int num_ranges) {
+    slotRangeArray *sra = zcalloc(sizeof(slotRangeArray) + num_ranges * sizeof(slotRange));
+    sra->num_ranges = num_ranges;
+    return sra;
+}
+
+/* Duplicate the slot range array. */
+slotRangeArray *slotRangeArrayDup(slotRangeArray *sra) {
+    slotRangeArray *dup = slotRangeArrayCreate(sra->num_ranges);
+    memcpy(dup->ranges, sra->ranges, sizeof(slotRange) * sra->num_ranges);
+    return dup;
+}
+
+/* Set the slot range at the specified index. */
+void slotRangeArraySet(slotRangeArray *sra, int idx, int start, int end) {
+    sra->ranges[idx].start = start;
+    sra->ranges[idx].end = end;
+}
+
+/* Create a slot range string in the format of: "1000-2000 3000-4000 ..." */
+sds slotRangeArrayToString(slotRangeArray *sra) {
+    sds s = sdsempty();
+
+    for (int i = 0; i < sra->num_ranges; i++) {
+        slotRange *sr = &sra->ranges[i];
+        s = sdscatprintf(s, "%d-%d ", sr->start, sr->end);
+    }
+    sdssetlen(s, sdslen(s) - 1);
+    s[sdslen(s)] = '\0';
+
+    return s;
+}
+
+/* Free the slot range array. */
+void slotRangeArrayFree(slotRangeArray *sra) {
+    zfree(sra);
+}
+
 /* Parse slot ranges from the command arguments. Returns NULL on error. */
 slotRangeArray *parseSlotRangesOrReply(client *c, int argc, int pos) {
     int start, end, count;
@@ -1681,25 +1720,24 @@ slotRangeArray *parseSlotRangesOrReply(client *c, int argc, int pos) {
     serverAssert((argc - pos) % 2 == 0);
 
     count = (argc - pos) / 2;
-    sra = zcalloc(sizeof(*sra) + count * sizeof(slotRange));
+    sra = slotRangeArrayCreate(count);
     sra->num_ranges = 0;
 
     for (int j = pos; j < argc; j += 2) {
         if ((start = getSlotOrReply(c, c->argv[j])) == -1 ||
             (end = getSlotOrReply(c, c->argv[j + 1])) == -1)
         {
-            zfree(sra);
+            slotRangeArrayFree(sra);
             return NULL;
         }
-        sra->ranges[sra->num_ranges].start = start;
-        sra->ranges[sra->num_ranges].end = end;
+        slotRangeArraySet(sra, sra->num_ranges, start, end);
         sra->num_ranges++;
     }
 
     sds err = NULL;
     if (validateSlotRanges(sra, &err) != C_OK) {
         addReplyErrorSds(c, err);
-        zfree(sra);
+        slotRangeArrayFree(sra);
         return NULL;
     }
     return sra;
@@ -1805,18 +1843,3 @@ void readwriteCommand(client *c) {
 void clusterCommonInit(void) {
     clusterAsmInit();
 }
-
-/* Create a slot range string in the format of: "1000-2000 3000-4000 ..." */
-sds createSlotRangesStr(slotRangeArray *slot_ranges) {
-    sds s = sdsempty();
-
-    for (int i = 0; i < slot_ranges->num_ranges; i++) {
-        slotRange *sr = &slot_ranges->ranges[i];
-        s = sdscatprintf(s, "%d-%d ", sr->start, sr->end);
-    }
-    sdssetlen(s, sdslen(s) - 1);
-    s[sdslen(s)] = '\0';
-
-    return s;
-}
-

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -239,10 +239,12 @@ int clusterNodeTlsPort(clusterNode *node);
  *  ASM_EVENT_HANDOFF
  *  ASM_EVENT_DONE
  *
- *  In case of ASM_EVENT_IMPORT_START, 'task_id' should be a unique string.
+ * In case of ASM_EVENT_IMPORT_START, 'task_id' should be a unique string.
+ * For other events (ASM_EVENT_CANCEL, ASM_EVENT_HANDOFF, ASM_EVENT_DONE),
+ * 'task_id' should match the ID from the corresponding import operation.
  *    Usage:
  *      char *task_id = malloc(CLUSTER_NAMELEN + 1);
- *      generateTaskID(task_id);
+ *      getRandomHexChars(task_id, CLUSTER_NAMELEN);
  *      task_id[CLUSTER_NAMELEN] = '\0';
  *
  *      slotRangeArray *sra  = zmalloc(sizeof(*sra) + sizeof(slotRange));
@@ -260,9 +262,10 @@ int clusterNodeTlsPort(clusterNode *node);
  *          return;
  *      }
  *
- * For ASM_EVENT_CANCEL, returns the number of cancelled tasks.
- * Otherwise, returns C_OK on success, C_ERR on failure. 'err' will be set to
- * the error message.
+ * Return value:
+ *  For ASM_EVENT_CANCEL, returns the number of cancelled tasks.
+ *  Otherwise, returns C_OK on success, C_ERR on failure. 'err' will be set to
+ *  the error message.
  *
  * Memory management:
  *  - There is no ownership transfer of 'task_id', 'err' or `slotRangeArray`.

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -151,7 +151,11 @@ typedef struct slotRangeArray {
     int num_ranges;
     slotRange ranges[];
 } slotRangeArray;
-sds createSlotRangesStr(slotRangeArray *slot_ranges);
+slotRangeArray *slotRangeArrayCreate(int num_ranges);
+slotRangeArray *slotRangeArrayDup(slotRangeArray *sra);
+void slotRangeArraySet(slotRangeArray *sra, int idx, int start, int end);
+sds slotRangeArrayToString(slotRangeArray *sra);
+void slotRangeArrayFree(slotRangeArray *sra);
 int validateSlotRanges(slotRangeArray *sra, sds *err);
 slotRangeArray *parseSlotRangesOrReply(client *c, int argc, int pos);
 

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -263,9 +263,9 @@ int clusterNodeTlsPort(clusterNode *node);
  *      }
  *
  * Return value:
- *  For ASM_EVENT_CANCEL, returns the number of cancelled tasks.
- *  Otherwise, returns C_OK on success, C_ERR on failure. 'err' will be set to
- *  the error message.
+ *  - For ASM_EVENT_CANCEL, returns the number of cancelled tasks.
+ *  - For all other events, returns C_OK on success, C_ERR on failure and 'err'
+ *    will be set to the error message.
  *
  * Memory management:
  *  - There is no ownership transfer of 'task_id', 'err' or `slotRangeArray`.

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -239,7 +239,7 @@ int clusterNodeTlsPort(clusterNode *node);
  *  ASM_EVENT_HANDOFF
  *  ASM_EVENT_DONE
  *
- * In case of ASM_EVENT_IMPORT_START, 'task_id' should be a unique string.
+ * For ASM_EVENT_IMPORT_START, 'task_id' should be a unique string.
  * For other events (ASM_EVENT_CANCEL, ASM_EVENT_HANDOFF, ASM_EVENT_DONE),
  * 'task_id' should match the ID from the corresponding import operation.
  *    Usage:
@@ -252,7 +252,7 @@ int clusterNodeTlsPort(clusterNode *node);
  *      sra->ranges[0].start = 0;
  *      sra->ranges[0].end = 1000;
  *
- *      const char *err;
+ *      const char *err = NULL;
  *      int ret = clusterAsmProcess(task_id, ASM_EVENT_IMPORT_START, sra, &err);
  *      free(task_id);
  *      free(sra);
@@ -262,10 +262,13 @@ int clusterNodeTlsPort(clusterNode *node);
  *          return;
  *      }
  *
+ * For ASM_EVENT_CANCEL, if `task_id` is NULL, all tasks will be cancelled.
+ * If `arg` parameter is provided, it should be a pointer to an int. It will be
+ * set to the number of tasks cancelled.
+ *
  * Return value:
- *  - For ASM_EVENT_CANCEL, returns the number of cancelled tasks.
- *  - For all other events, returns C_OK on success, C_ERR on failure and 'err'
- *    will be set to the error message.
+ *  - Returns C_OK on success, C_ERR on failure and 'err' will be set to the
+ *    error message.
  *
  * Memory management:
  *  - There is no ownership transfer of 'task_id', 'err' or `slotRangeArray`.

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -143,6 +143,14 @@ int isValidAuxString(char *s, unsigned int length);
 void migrateCommand(client *c);
 void clusterCommand(client *c);
 ConnectionType *connTypeOfCluster(void);
+
+typedef struct slotRange {
+    unsigned short start, end;
+} slotRange;
+typedef struct slotRangeArray {
+    int num_ranges;
+    slotRange ranges[];
+} slotRangeArray;
 sds createSlotRangesStr(slotRangeArray *slot_ranges);
 int validateSlotRanges(slotRangeArray *sra, sds *err);
 slotRangeArray *parseSlotRangesOrReply(client *c, int argc, int pos);

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -239,8 +239,7 @@ int clusterNodeTlsPort(clusterNode *node);
  *  ASM_EVENT_HANDOFF
  *  ASM_EVENT_DONE
  *
- *  In case of ASM_EVENT_IMPORT_START, 'task_id' should be unique and should be
- *  CLUSTER_NAMELEN characters long.
+ *  In case of ASM_EVENT_IMPORT_START, 'task_id' should be a unique string.
  *    Usage:
  *      char *task_id = malloc(CLUSTER_NAMELEN + 1);
  *      generateTaskID(task_id);
@@ -261,7 +260,7 @@ int clusterNodeTlsPort(clusterNode *node);
  *          return;
  *      }
  *
- * In case of ASM_EVENT_CANCEL, returns the number of cancelled tasks.
+ * For ASM_EVENT_CANCEL, returns the number of cancelled tasks.
  * Otherwise, returns C_OK on success, C_ERR on failure. 'err' will be set to
  * the error message.
  *
@@ -275,7 +274,7 @@ int clusterAsmProcess(const char *task_id, int event, void *arg, char **err);
 
 /* Called when an ASM event occurs to notify implementation/plugin. (redis --> plugin)
  *
- * `arg` will point to a `slotRangeArray` for the following events`:
+ * `arg` will point to a `slotRangeArray` for the following events:
  *  ASM_EVENT_IMPORT_STARTED
  *  ASM_EVENT_MIGRATE_STARTED
  *  ASM_EVENT_HANDOFF_PREP

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -239,28 +239,39 @@ int clusterNodeTlsPort(clusterNode *node);
  *  ASM_EVENT_HANDOFF
  *  ASM_EVENT_DONE
  *
- *  In case of ASM_EVENT_IMPORT_START, 'task_id' will be set to the task id of
- *  the import task. For this event, task_id should be NULL initially.
+ *  In case of ASM_EVENT_IMPORT_START, 'task_id' should be unique and should be
+ *  CLUSTER_NAMELEN characters long.
  *    Usage:
- *      sds task_id = NULL, err = NULL;
+ *      char *task_id = malloc(CLUSTER_NAMELEN + 1);
+ *      generateTaskID(task_id);
+ *      task_id[CLUSTER_NAMELEN] = '\0';
+ *
  *      slotRangeArray *sra  = zmalloc(sizeof(*sra) + sizeof(slotRange));
  *      sra->num_ranges = 1;
  *      sra->ranges[0].start = 0;
  *      sra->ranges[0].end = 1000;
  *
- *      if (clusterAsmProcess(&task_id, ASM_EVENT_IMPORT_START, sra, &err) != C_OK) {
- *          // Handle error
- *          sdsfree(err);
+ *      const char *err;
+ *      int ret = clusterAsmProcess(task_id, ASM_EVENT_IMPORT_START, sra, &err);
+ *      free(task_id);
+ *      free(sra);
+ *
+ *      if (ret != C_OK) {
+ *          perror(err);
  *          return;
  *      }
- *      // task_id is set to the task id of the import task
  *
- *  For other events, 'task_id' should be set to the task id of the task.
+ * In case of ASM_EVENT_CANCEL, returns the number of cancelled tasks.
+ * Otherwise, returns C_OK on success, C_ERR on failure. 'err' will be set to
+ * the error message.
  *
- * Returns C_OK on success, C_ERR on failure. 'err' will be set to the error
- * message and should be freed by the caller.
+ * Memory management:
+ *  - There is no ownership transfer of 'task_id', 'err' or `slotRangeArray`.
+ *  - `task_id` and `slotRangeArray` should be allocated and be freed by the
+ *     caller. Redis internally will make a copy of these.
+ *  - `err` is allocated by Redis and should NOT be freed by the caller.
  **/
-int clusterAsmProcess(sds *task_id, int event, void *arg, sds *err);
+int clusterAsmProcess(const char *task_id, int event, void *arg, char **err);
 
 /* Called when an ASM event occurs to notify implementation/plugin. (redis --> plugin)
  *
@@ -269,8 +280,11 @@ int clusterAsmProcess(sds *task_id, int event, void *arg, sds *err);
  *  ASM_EVENT_MIGRATE_STARTED
  *  ASM_EVENT_HANDOFF_PREP
  *
+ *  Memory management:
+ *  - Redis owns the `task_id` and `slotRangeArray`.
+ *
  *  Returns C_OK on success.
  **/
-int clusterAsmOnEvent(sds task_id, int event, void *arg);
+int clusterAsmOnEvent(const char *task_id, int event, void *arg);
 
 #endif /* __CLUSTER_H */

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -1883,10 +1883,8 @@ int asmNotifyConfigUpdated(slotRangeArray *slot_ranges, sds *err) {
     asmTask *task = lookupAsmTaskBySlotRangeArray(slot_ranges);
     if (!task) {
         sds slot_ranges_str = createSlotRangesStr(slot_ranges);
-        sds errmsg = sdscatprintf(sdsempty(), "No ASM task found for slots: %s", slot_ranges_str);
+        *err = sdscatprintf(sdsempty(), "No ASM task found for slots: %s", slot_ranges_str);
         sdsfree(slot_ranges_str);
-        serverLog(LL_WARNING, "%s", errmsg);
-        if (err) *err = errmsg;
         return C_ERR;
     }
 
@@ -1904,11 +1902,9 @@ int asmNotifyConfigUpdated(slotRangeArray *slot_ranges, sds *err) {
         asmTaskComplete(task);
         return C_OK;
     } else {
-        sds errmsg = sdscatprintf(sdsempty(),
+        *err = sdscatprintf(sdsempty(),
                                   "ASM task is not in the correct state for config update: %s",
                                   asmTaskStateToString(task->state));
-        serverLog(LL_WARNING, "%s", errmsg);
-        if (err) *err = errmsg;
         return C_ERR;
     }
 

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -109,7 +109,7 @@ int startBgsaveForReplication(int mincapa, int req);
 void createReplicationBacklogIfNeeded(void);
 static void asmSyncBufferReadFromConn(connection *conn);
 void asmTaskSetFailed(asmTask *task, const char *fmt, ...);
-int clusterAsmCancel(sds *task_id, sds *err);
+int clusterAsmCancel(const char *task_id);
 
 void clusterAsmInit(void) {
     asmManager = zcalloc(sizeof(*asmManager));
@@ -232,7 +232,7 @@ void asmTaskReset(asmTask *task) {
     task->rdb_channel_client = NULL;
 }
 
-asmTask *asmTaskCreate(sds task_id) {
+asmTask *asmTaskCreate(const char *task_id) {
     asmTask *task = zcalloc(sizeof(*task));
     task->error = sdsempty();
     asmTaskReset(task);
@@ -243,7 +243,7 @@ asmTask *asmTaskCreate(sds task_id) {
     task->start_time = -1;
     task->done_time = -1;
     if (task_id) {
-        task->id = sdsdup(task_id);
+        task->id = sdsnew(task_id);
     } else {
         task->id = sdsnewlen(NULL, CLUSTER_NAMELEN);
         getRandomHexChars(task->id, CLUSTER_NAMELEN);
@@ -298,7 +298,7 @@ static int slotRangeArrayIsEqual(slotRangeArray *sra1, slotRangeArray *sra2) {
 }
 
 /* Returns the ASM task with the given ID, or NULL if no such task exists. */
-asmTask *lookupAsmTaskById(sds id) {
+asmTask *lookupAsmTaskById(const char *id) {
     listIter li;
     listNode *ln;
 
@@ -326,7 +326,7 @@ asmTask *lookupAsmTaskBySlotRangeArray(slotRangeArray *sra) {
 }
 
 /* Returns the slot range array for the given task ID */
-slotRangeArray *asmTaskGetSlotRanges(sds task_id) {
+slotRangeArray *asmTaskGetSlotRanges(const char *task_id) {
     asmTask *task = NULL;
     if (!task_id || (task = lookupAsmTaskById(task_id)) == NULL) return NULL;
 
@@ -490,7 +490,7 @@ void asmFeedMigrationClient(robj **argv, int argc) {
     task->source_offset += (getNormalClientPendingReplyBytes(c) - prev_bytes);
 }
 
-sds asmCreateImportTask(slotRangeArray *slot_ranges, sds *err) {
+asmTask *asmCreateImportTask(const char *task_id, slotRangeArray *slot_ranges, sds *err) {
     clusterNode *source;
 
     *err = NULL;
@@ -515,7 +515,7 @@ sds asmCreateImportTask(slotRangeArray *slot_ranges, sds *err) {
     }
 
     /* Create a slot migration task */
-    asmTask *task = asmTaskCreate(NULL);
+    asmTask *task = asmTaskCreate(task_id);
     task->slot_ranges = slot_ranges;
     task->state = ASM_NONE;
     task->operation = ASM_IMPORT;
@@ -534,7 +534,7 @@ sds asmCreateImportTask(slotRangeArray *slot_ranges, sds *err) {
      * to the slot range, and generate a big MULTI-EXEC, even this command itself
      * also be part of the MULTI-EXEC. So we will do it in beforeSleep(). */
 
-    return task->id;
+    return task;
 }
 
 /* CLUSTER MIGRATION IMPORT <start-slot end-slot [start-slot end-slot ...]>
@@ -552,13 +552,13 @@ static void clusterMigrationCommandImport(client *c) {
     if (!slot_ranges) return;
 
     sds err = NULL;
-    sds task_id = asmCreateImportTask(slot_ranges, &err);
-    if (!task_id) {
+    asmTask *task = asmCreateImportTask(NULL, slot_ranges, &err);
+    if (!task) {
         addReplyErrorSds(c, err);
         return;
     }
 
-    addReplyBulkCString(c, task_id);
+    addReplyBulkCString(c, task->id);
 }
 
 /* CLUSTER MIGRATION CANCEL [ID <id> | ALL]
@@ -567,7 +567,6 @@ static void clusterMigrationCommandImport(client *c) {
  * Cancels import tasks that overlap with the specified slot ranges.
  * Multiple tasks may be cancelled. */
 static void clusterMigrationCommandCancel(client *c) {
-    sds err = NULL;
     sds task_id = NULL;
     int num_cancelled = 0;
 
@@ -593,12 +592,7 @@ static void clusterMigrationCommandCancel(client *c) {
         return;
     }
 
-    num_cancelled = clusterAsmCancel(&task_id, &err);
-    if (num_cancelled < 0) {
-        addReplyError(c, err);
-        sdsfree(err);
-        return;
-    }
+    num_cancelled = clusterAsmCancel(task_id);
     addReplyLongLong(c, num_cancelled);
 }
 
@@ -1840,14 +1834,9 @@ void asmCron(void) {
 }
 
 /* Cancel a specific task if ID is provided, otherwise cancel all tasks. */
-int clusterAsmCancel(sds *task_id, sds *err) {
-    if (*task_id) {
-        if (sdslen(*task_id) != CLUSTER_NAMELEN) {
-            *err = sdsnew("Invalid task id");
-            return -1;
-        }
-
-        asmTask *task = lookupAsmTaskById(*task_id);
+int clusterAsmCancel(const char *task_id) {
+    if (task_id) {
+        asmTask *task = lookupAsmTaskById(task_id);
         if (!task) return 0; /* Not found */
 
         asmTaskCancel(task);
@@ -1867,11 +1856,15 @@ int clusterAsmCancel(sds *task_id, sds *err) {
     }
 }
 
-int clusterAsmHandoff(sds *task_id, sds *err) {
+int clusterAsmHandoff(const char *task_id, sds *err) {
     UNUSED(err);
 
-    asmTask *task = lookupAsmTaskById(*task_id);
-    if (!task || task->state != ASM_HANDOFF_PREP) return C_ERR;
+    asmTask *task = lookupAsmTaskById(task_id);
+    if (!task || task->state != ASM_HANDOFF_PREP) {
+        *err = sdscatprintf(sdsempty(), "No suitable ASM task found for id: %s, task_state: %s",
+                            task_id, task ? asmTaskStateToString(task->state) : "null");
+        return C_ERR;
+    }
 
     task->state = ASM_HANDOFF;
     task->paused_time = server.mstime;
@@ -1880,14 +1873,14 @@ int clusterAsmHandoff(sds *task_id, sds *err) {
 }
 
 int asmNotifyConfigUpdated(slotRangeArray *slot_ranges, sds *err) {
-    UNUSED(err);
     /* TODO: Validation, cancel asmTasks if required */
 
     asmTask *task = lookupAsmTaskBySlotRangeArray(slot_ranges);
     if (!task) {
         sds slot_ranges_str = createSlotRangesStr(slot_ranges);
-        serverLog(LL_WARNING, "No ASM task found for slots: %s", slot_ranges_str);
+        *err = sdscatprintf(sdsempty(), "No ASM task found for slots: %s", slot_ranges_str);
         sdsfree(slot_ranges_str);
+        serverLog(LL_WARNING, "%s", *err);
         return C_ERR;
     }
 
@@ -1905,8 +1898,10 @@ int asmNotifyConfigUpdated(slotRangeArray *slot_ranges, sds *err) {
         asmTaskComplete(task);
         return C_OK;
     } else {
-        serverLog(LL_WARNING, "ASM task is not in the correct state for config update: %s",
-                  asmTaskStateToString(task->state));
+        *err = sdscatprintf(sdsempty(),
+                            "ASM task is not in the correct state for config update: %s",
+                            asmTaskStateToString(task->state));
+        serverLog(LL_WARNING, "%s", *err);
         return C_ERR;
     }
 
@@ -1914,32 +1909,44 @@ int asmNotifyConfigUpdated(slotRangeArray *slot_ranges, sds *err) {
 }
 
 /* Import/Migrate task is done, config is updated. */
-int clusterAsmDone(sds *task_id, sds *err) {
-    UNUSED(err);
-    asmTask *task = lookupAsmTaskById(*task_id);
+int clusterAsmDone(const char *task_id, sds *err) {
+    asmTask *task = lookupAsmTaskById(task_id);
     if (!task) {
-        *err = sdscatprintf(sdsempty(), "No ASM task found for id: %s", *task_id);
+        *err = sdscatprintf(sdsempty(), "No ASM task found for id: %s", task_id);
         return C_ERR;
     }
     return asmNotifyConfigUpdated(task->slot_ranges, err);
 }
 
-int clusterAsmProcess(sds *task_id, int event, void *arg, sds *err) {
-    UNUSED(arg);
+int clusterAsmProcess(const char *task_id, int event, void *arg, char **err) {
+    int ret;
+    sds errsds = NULL;
+    static char buf[256];
+
+    if (err) *err = NULL;
 
     switch (event) {
         case ASM_EVENT_IMPORT_START:
-            *task_id = asmCreateImportTask(arg, err);
-            if (!*task_id) return C_ERR;
-            return C_OK;
+            ret = asmCreateImportTask(task_id, arg, &errsds) ? C_OK : C_ERR;
+            break;
         case ASM_EVENT_CANCEL:
-            return clusterAsmCancel(task_id, err);
+            return clusterAsmCancel(task_id);
         case ASM_EVENT_HANDOFF:
-            return clusterAsmHandoff(task_id, err);
+            ret = clusterAsmHandoff(task_id, &errsds);
+            break;
         case ASM_EVENT_DONE:
-            return clusterAsmDone(task_id, err);
+            ret = clusterAsmDone(task_id, &errsds);
+            break;
         default:
-            *err = sdscatprintf(sdsempty(), "Unknown operation: %d", event);
-            return C_ERR;
+            ret = C_ERR;
+            errsds = sdscatprintf(sdsempty(), "Unknown operation: %d", event);
+            break;
     }
+
+    if (ret != C_OK && errsds && err) {
+        snprintf(buf, sizeof(buf), "%s", errsds);
+        sdsfree(errsds);
+        *err = buf;
+    }
+    return ret;
 }

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -297,6 +297,14 @@ static int slotRangeArrayIsEqual(slotRangeArray *sra1, slotRangeArray *sra2) {
     return 1;
 }
 
+/* Copies the slot ranges array. */
+slotRangeArray *dupSlotRangeArray(slotRangeArray *sra) {
+    slotRangeArray *dup = zmalloc(sizeof(*dup) + sizeof(slotRange) * sra->num_ranges);
+    dup->num_ranges = sra->num_ranges;
+    memcpy(dup->ranges, sra->ranges, sizeof(slotRange) * sra->num_ranges);
+    return dup;
+}
+
 /* Returns the ASM task with the given ID, or NULL if no such task exists. */
 asmTask *lookupAsmTaskById(const char *id) {
     listIter li;
@@ -497,26 +505,22 @@ asmTask *asmCreateImportTask(const char *task_id, slotRangeArray *slot_ranges, s
     /* Validate that the slot ranges are valid and that migration can be
      * initiated for them. */
     source = validateImportSlotRanges(slot_ranges, err);
-    if (!source) {
-        zfree(slot_ranges);
+    if (!source)
         return NULL;
-    }
 
     if (source == getMyClusterNode()) {
         *err = sdsnew("this node is already the owner of the slot range");
-        zfree(slot_ranges);
         return NULL;
     }
 
     if (listLength(asmManager->tasks) != 0) {
         *err = sdsnew("another ASM task is already in progress");
-        zfree(slot_ranges);
         return NULL;
     }
 
     /* Create a slot migration task */
     asmTask *task = asmTaskCreate(task_id);
-    task->slot_ranges = slot_ranges;
+    task->slot_ranges = dupSlotRangeArray(slot_ranges);
     task->state = ASM_NONE;
     task->operation = ASM_IMPORT;
     task->source_node = source;
@@ -553,6 +557,7 @@ static void clusterMigrationCommandImport(client *c) {
 
     sds err = NULL;
     asmTask *task = asmCreateImportTask(NULL, slot_ranges, &err);
+    zfree(slot_ranges);
     if (!task) {
         addReplyErrorSds(c, err);
         return;

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -1883,9 +1883,10 @@ int asmNotifyConfigUpdated(slotRangeArray *slot_ranges, sds *err) {
     asmTask *task = lookupAsmTaskBySlotRangeArray(slot_ranges);
     if (!task) {
         sds slot_ranges_str = createSlotRangesStr(slot_ranges);
-        *err = sdscatprintf(sdsempty(), "No ASM task found for slots: %s", slot_ranges_str);
+        sds errmsg = sdscatprintf(sdsempty(), "No ASM task found for slots: %s", slot_ranges_str);
         sdsfree(slot_ranges_str);
-        serverLog(LL_WARNING, "%s", *err);
+        serverLog(LL_WARNING, "%s", errmsg);
+        if (err) *err = errmsg;
         return C_ERR;
     }
 
@@ -1903,10 +1904,11 @@ int asmNotifyConfigUpdated(slotRangeArray *slot_ranges, sds *err) {
         asmTaskComplete(task);
         return C_OK;
     } else {
-        *err = sdscatprintf(sdsempty(),
-                            "ASM task is not in the correct state for config update: %s",
-                            asmTaskStateToString(task->state));
-        serverLog(LL_WARNING, "%s", *err);
+        sds errmsg = sdscatprintf(sdsempty(),
+                                  "ASM task is not in the correct state for config update: %s",
+                                  asmTaskStateToString(task->state));
+        serverLog(LL_WARNING, "%s", errmsg);
+        if (err) *err = errmsg;
         return C_ERR;
     }
 

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -1894,7 +1894,7 @@ int clusterAsmCancel(const char *task_id) {
 }
 
 int clusterAsmHandoff(const char *task_id, sds *err) {
-    UNUSED(err);
+    serverAssert(task_id);
 
     asmTask *task = lookupAsmTaskById(task_id);
     if (!task || task->state != ASM_HANDOFF_PREP) {
@@ -1935,8 +1935,8 @@ int asmNotifyConfigUpdated(slotRangeArray *slot_ranges, sds *err) {
         return C_OK;
     } else {
         *err = sdscatprintf(sdsempty(),
-                                  "ASM task is not in the correct state for config update: %s",
-                                  asmTaskStateToString(task->state));
+                            "ASM task is not in the correct state for config update: %s",
+                            asmTaskStateToString(task->state));
         return C_ERR;
     }
 
@@ -1945,6 +1945,8 @@ int asmNotifyConfigUpdated(slotRangeArray *slot_ranges, sds *err) {
 
 /* Import/Migrate task is done, config is updated. */
 int clusterAsmDone(const char *task_id, sds *err) {
+    serverAssert(task_id);
+
     asmTask *task = lookupAsmTaskById(task_id);
     if (!task) {
         *err = sdscatprintf(sdsempty(), "No ASM task found for id: %s", task_id);
@@ -1954,7 +1956,7 @@ int clusterAsmDone(const char *task_id, sds *err) {
 }
 
 int clusterAsmProcess(const char *task_id, int event, void *arg, char **err) {
-    int ret;
+    int ret, num_cancelled;
     sds errsds = NULL;
     static char buf[256];
 
@@ -1965,7 +1967,10 @@ int clusterAsmProcess(const char *task_id, int event, void *arg, char **err) {
             ret = asmCreateImportTask(task_id, arg, &errsds) ? C_OK : C_ERR;
             break;
         case ASM_EVENT_CANCEL:
-            return clusterAsmCancel(task_id);
+            num_cancelled = clusterAsmCancel(task_id);
+            if (arg) *((int *)arg) = num_cancelled;
+            ret = C_OK;
+            break;
         case ASM_EVENT_HANDOFF:
             ret = clusterAsmHandoff(task_id, &errsds);
             break;
@@ -1980,8 +1985,9 @@ int clusterAsmProcess(const char *task_id, int event, void *arg, char **err) {
 
     if (ret != C_OK && errsds && err) {
         snprintf(buf, sizeof(buf), "%s", errsds);
-        sdsfree(errsds);
         *err = buf;
     }
+    sdsfree(errsds);
+
     return ret;
 }

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -325,14 +325,6 @@ static int slotRangeArrayIsEqual(slotRangeArray *sra1, slotRangeArray *sra2) {
     return 1;
 }
 
-/* Copies the slot ranges array. */
-slotRangeArray *dupSlotRangeArray(slotRangeArray *sra) {
-    slotRangeArray *dup = zmalloc(sizeof(*dup) + sizeof(slotRange) * sra->num_ranges);
-    dup->num_ranges = sra->num_ranges;
-    memcpy(dup->ranges, sra->ranges, sizeof(slotRange) * sra->num_ranges);
-    return dup;
-}
-
 /* Returns the ASM task with the given ID, or NULL if no such task exists. */
 asmTask *lookupAsmTaskById(const char *id) {
     listIter li;
@@ -548,7 +540,7 @@ asmTask *asmCreateImportTask(const char *task_id, slotRangeArray *slot_ranges, s
 
     /* Create a slot migration task */
     asmTask *task = asmTaskCreate(task_id);
-    task->slot_ranges = dupSlotRangeArray(slot_ranges);
+    task->slot_ranges = slotRangeArrayDup(slot_ranges);
     task->state = ASM_NONE;
     task->operation = ASM_IMPORT;
     task->source_node = source;
@@ -556,7 +548,7 @@ asmTask *asmCreateImportTask(const char *task_id, slotRangeArray *slot_ranges, s
     memcpy(task->dest, getMyClusterId(), CLUSTER_NAMELEN);
 
     listAddNodeTail(asmManager->tasks, task);
-    sds slot_ranges_str = createSlotRangesStr(slot_ranges);
+    sds slot_ranges_str = slotRangeArrayToString(slot_ranges);
     serverLog(LL_NOTICE, "Import task created: src=%.40s, dest=%.40s, slots=%s",
                          task->source, task->dest, slot_ranges_str);
     sdsfree(slot_ranges_str);
@@ -637,7 +629,7 @@ static void replyTaskStatus(client *c, asmTask *task) {
     addReplyBulkCString(c, "id");
     addReplyBulkCString(c, task->id);
     addReplyBulkCString(c, "slots_range");
-    addReplyBulkSds(c, createSlotRangesStr(task->slot_ranges));
+    addReplyBulkSds(c, slotRangeArrayToString(task->slot_ranges));
     addReplyBulkCString(c, "source");
     addReplyBulkCBuffer(c, task->source, CLUSTER_NAMELEN);
     addReplyBulkCString(c, "dest");
@@ -783,7 +775,7 @@ void asmTaskSetFailed(asmTask *task, const char *fmt, ...) {
     task->error = error;
 
     /* Log the error */
-    sds slot_ranges_str = createSlotRangesStr(task->slot_ranges);
+    sds slot_ranges_str = slotRangeArrayToString(task->slot_ranges);
     serverLog(LL_WARNING, "%s task failed. slots=%s, err=%s",
               task->operation == ASM_IMPORT ? "Import" : "Migrate",
               slot_ranges_str, task->error);
@@ -1302,7 +1294,7 @@ void clusterSyncSlotsStreamEOF(client *c) {
 void asmStartImportTask(asmTask *task) {
     if (task->operation != ASM_IMPORT || task->state != ASM_NONE) return;
 
-    sds slot_ranges_str = createSlotRangesStr(task->slot_ranges);
+    sds slot_ranges_str = slotRangeArrayToString(task->slot_ranges);
     serverLog(LL_NOTICE, "Import task starting: src=%.40s, dest=%.40s, slots=%s",
               task->source, task->dest, slot_ranges_str);
     sdsfree(slot_ranges_str);
@@ -1418,7 +1410,7 @@ void clusterSyncSlotsCommand(client *c) {
         /* Wait for RDB channel to be ready */
         task->state = ASM_WAIT_RDBCHANNEL;
 
-        sds slot_ranges_str = createSlotRangesStr(slot_ranges);
+        sds slot_ranges_str = slotRangeArrayToString(slot_ranges);
         serverLog(LL_NOTICE, "Migrate task created: src=%.40s, dest=%.40s, slots=%s",
                               task->source, task->dest, slot_ranges_str);
         sdsfree(slot_ranges_str);
@@ -1914,7 +1906,7 @@ int asmNotifyConfigUpdated(slotRangeArray *slot_ranges, sds *err) {
 
     asmTask *task = lookupAsmTaskBySlotRangeArray(slot_ranges);
     if (!task) {
-        sds slot_ranges_str = createSlotRangesStr(slot_ranges);
+        sds slot_ranges_str = slotRangeArrayToString(slot_ranges);
         *err = sdscatprintf(sdsempty(), "No ASM task found for slots: %s", slot_ranges_str);
         sdsfree(slot_ranges_str);
         return C_ERR;

--- a/src/cluster_asm.h
+++ b/src/cluster_asm.h
@@ -11,6 +11,7 @@
 #define CLUSTER_ASM_H
 
 struct asmTask;
+struct slotRangeArray;
 
 void clusterAsmInit(void);
 void asmBeforeSleep(void);
@@ -21,8 +22,8 @@ int asmMigrateInProgress(void);
 void asmFeedMigrationClient(robj **argv, int argc);
 int asmDebugSetFailPoint(char * channel, char *state);
 void asmImportIncrAppliedBytes(struct asmTask *task, size_t bytes);
-slotRangeArray *asmTaskGetSlotRanges(const char *task_id);
-int asmNotifyConfigUpdated(slotRangeArray *slot_ranges, sds *err);
+struct slotRangeArray *asmTaskGetSlotRanges(const char *task_id);
+int asmNotifyConfigUpdated(struct slotRangeArray *slot_ranges, sds *err);
 size_t asmGetPeakSyncBufferSize(void);
 int asmKeyBelongsToCurrentNode(kvobj *kv);
 

--- a/src/cluster_asm.h
+++ b/src/cluster_asm.h
@@ -21,7 +21,7 @@ int asmMigrateInProgress(void);
 void asmFeedMigrationClient(robj **argv, int argc);
 int asmDebugSetFailPoint(char * channel, char *state);
 void asmImportIncrAppliedBytes(struct asmTask *task, size_t bytes);
-slotRangeArray *asmTaskGetSlotRanges(sds task_id);
+slotRangeArray *asmTaskGetSlotRanges(const char *task_id);
 int asmNotifyConfigUpdated(slotRangeArray *slot_ranges, sds *err);
 size_t asmGetPeakSyncBufferSize(void);
 

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -6530,7 +6530,7 @@ int clusterAsmOnEvent(const char *task_id, int event, void *arg) {
     UNUSED(arg);
 
     slotRangeArray *slots = asmTaskGetSlotRanges(task_id);
-    sds str = createSlotRangesStr(slots);
+    sds str = slotRangeArrayToString(slots);
 
     switch (event) {
         case ASM_EVENT_IMPORT_STARTED:

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -6522,7 +6522,7 @@ void clusterPromoteSelfToMaster(void) {
     replicationUnsetMaster();
 }
 
-int clusterAsmOnEvent(sds task_id, int event, void *arg) {
+int clusterAsmOnEvent(const char *task_id, int event, void *arg) {
     UNUSED(arg);
 
     slotRangeArray *slots = asmTaskGetSlotRanges(task_id);
@@ -6549,7 +6549,7 @@ int clusterAsmOnEvent(sds task_id, int event, void *arg) {
             clusterBumpConfigEpochWithoutConsensus();
             clusterBroadcastPong(CLUSTER_BROADCAST_ALL);
             clusterSaveConfigOrDie(1);
-            clusterAsmProcess(&task_id, ASM_EVENT_DONE, NULL, NULL);
+            clusterAsmProcess(task_id, ASM_EVENT_DONE, NULL, NULL);
             break;
         case ASM_EVENT_IMPORT_COMPLETED:
             serverLog(LL_NOTICE, "Import task completed for slots: %s", str);
@@ -6566,7 +6566,7 @@ int clusterAsmOnEvent(sds task_id, int event, void *arg) {
             pauseActions(PAUSE_DURING_SLOT_HANDOFF,
                          LLONG_MAX,
                          PAUSE_ACTIONS_CLIENT_WRITE_SET);
-            clusterAsmProcess(&task_id, ASM_EVENT_HANDOFF, NULL, NULL);
+            clusterAsmProcess(task_id, ASM_EVENT_HANDOFF, NULL, NULL);
             break;
         case ASM_EVENT_MIGRATE_COMPLETED:
             serverLog(LL_NOTICE, "Migrate task completed for slots: %s", str);

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2444,7 +2444,11 @@ void clusterUpdateSlotsConfigWith(clusterNode *sender, uint64_t senderConfigEpoc
         sra->num_ranges++;
     }
     if (sra->num_ranges > 0 && server.masterhost == NULL) {
-        asmNotifyConfigUpdated(sra, NULL);
+        sds err = NULL;
+        if (asmNotifyConfigUpdated(sra, &err) != C_OK) {
+            serverLog(LL_WARNING, "ASM config update failed: %s", err);
+            sdsfree(err);
+        }
     }
     zfree(sra);
 

--- a/src/cluster_plugin.c
+++ b/src/cluster_plugin.c
@@ -340,7 +340,7 @@ const char *clusterGetSecret(size_t *len) {
     return clusterPlugin->clusterGetSecret(len);
 }
 
-int clusterAsmOnEvent(sds task_id, int event, void *arg) {
+int clusterAsmOnEvent(const char *task_id, int event, void *arg) {
     return clusterPlugin->clusterAsmOnEvent(task_id, event, arg);
 }
 

--- a/src/cluster_plugin.h
+++ b/src/cluster_plugin.h
@@ -64,7 +64,7 @@ typedef int (*clusterNodeTlsPortFunc)(clusterNode *node);
 
 typedef const char *(*clusterGetSecretFunc)(size_t *len);
 
-typedef int (*clusterAsmOnEventFunc)(sds task_id, int event, void *arg);
+typedef int (*clusterAsmOnEventFunc)(const char *task_id, int event, void *arg);
 
 typedef struct {
     clusterAllowFailoverCmdFunc clusterAllowFailoverCmd;

--- a/src/server.h
+++ b/src/server.h
@@ -3676,15 +3676,9 @@ kvobj *dbUnshareStringValueByLink(redisDb *db, robj *key, kvobj *kv, dictEntryLi
 #define FLUSH_TYPE_ALL   0
 #define FLUSH_TYPE_DB    1
 #define FLUSH_TYPE_SLOTS 2
-typedef struct slotRange {
-    unsigned short start, end;
-} slotRange;
-typedef struct slotRangeArray {
-    int num_ranges;
-    slotRange ranges[];
-} slotRangeArray;
-void replySlotsFlushAndFree(client *c, slotRangeArray *ranges);
-int flushCommandCommon(client *c, int type, int flags, slotRangeArray *ranges);
+struct slotRangeArray;
+void replySlotsFlushAndFree(client *c, struct slotRangeArray *ranges);
+int flushCommandCommon(client *c, int type, int flags, struct slotRangeArray *ranges);
 #define EMPTYDB_NO_FLAGS 0      /* No flags. */
 #define EMPTYDB_ASYNC (1<<0)    /* Reclaim memory in another thread. */
 #define EMPTYDB_NOFUNCTIONS (1<<1) /* Indicate not to flush the functions. */


### PR DESCRIPTION
PR involves some improvements to make plugin side development easier:
- Avoid using `sds` in the API. Internally, we are still using sds but in the plugin API uses `char*`. only.
- Allow plugin to generate `task_id`  for the ASM_EVENT_IMPORT_START event. 
- Error strings are stored in a static buffer in Redis to avoid requiring plugin to free it. 