### PR TITLE
some improvements for slot migration

### DIFF
--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -644,7 +644,7 @@ static void clusterMigrationCommandCancel(client *c) {
         return;
     }
 
-    num_cancelled = clusterAsmCancel(task_id);
+    num_cancelled = clusterAsmCancel(task_id, "user request");
     addReplyLongLong(c, num_cancelled);
 }
 
@@ -840,10 +840,10 @@ void asmTaskComplete(asmTask *task) {
     }
 }
 
-void asmTaskCancel(asmTask *task) {
+void asmTaskCancel(asmTask *task, const char *reason) {
     if (task->state == ASM_CANCELED) return;
 
-    asmTaskSetFailed(task, "Cancelled by user");
+    asmTaskSetFailed(task, "Cancelled due to %s", reason);
     task->state = ASM_CANCELED;
     asmTaskComplete(task);
 }
@@ -988,6 +988,12 @@ void asmRdbChannelSyncWithSource(connection *conn) {
         err = receiveSynchronousResponse(conn);
         /* The destination node did not reply */
         if (err == NULL) goto no_response_error;
+
+        /* Ignore `\n` that may be sent to keep the connection alive */
+        if (sdslen(err) == 0) {
+            sdsfree(err);
+            return;
+        }
 
         /* Check `+SLOTSSNAPSHOT` reply */
         if (!strncmp(err, "+SLOTSSNAPSHOT", strlen("+SLOTSSNAPSHOT"))) {
@@ -1409,7 +1415,7 @@ void clusterSyncSlotsCommand(client *c) {
         } else if (task) {
             if (task->state == ASM_FAILED) {
                 /* Cancel the failed task, and create new one. */
-                asmTaskCancel(task);
+                asmTaskCancel(task, "new task requested");
                 task = NULL;
             } else {
                 addReplyError(c, "Another migration task is already in progress");
@@ -1948,14 +1954,14 @@ void asmCron(void) {
 }
 
 /* Cancel a specific task if ID is provided, otherwise cancel all tasks. */
-int clusterAsmCancel(const char *task_id) {
+int clusterAsmCancel(const char *task_id, const char *reason) {
     if (asmManager == NULL) return 0;
 
     if (task_id) {
         asmTask *task = lookupAsmTaskById(task_id);
         if (!task) return 0; /* Not found */
 
-        asmTaskCancel(task);
+        asmTaskCancel(task, reason);
         return 1;
     } else {
         int num_cancelled = 0;
@@ -1965,7 +1971,7 @@ int clusterAsmCancel(const char *task_id) {
         listRewind(asmManager->tasks, &li);
         while ((ln = listNext(&li)) != NULL) {
             asmTask *task = listNodeValue(ln);
-            asmTaskCancel(task);
+            asmTaskCancel(task, reason);
             num_cancelled++;
         }
         return num_cancelled;
@@ -1974,7 +1980,7 @@ int clusterAsmCancel(const char *task_id) {
 
 /* Cancel all tasks that overlap with the given slot ranges.
  * If slot_ranges is NULL, cancel all tasks. */
-int clusterAsmCancelBySlotRangeArray(struct slotRangeArray *slot_ranges) {
+int clusterAsmCancelBySlotRangeArray(struct slotRangeArray *slot_ranges, const char *reason) {
     if (asmManager == NULL) return 0;
 
     int num_cancelled = 0;
@@ -1984,7 +1990,7 @@ int clusterAsmCancelBySlotRangeArray(struct slotRangeArray *slot_ranges) {
     while ((ln = listNext(&li)) != NULL) {
         asmTask *task = listNodeValue(ln);
         if (!slot_ranges || slotRangeArraysOverlap(task->slot_ranges, slot_ranges)) {
-            asmTaskCancel(task);
+            asmTaskCancel(task, reason);
             num_cancelled++;
         }
     }
@@ -2065,7 +2071,7 @@ int clusterAsmProcess(const char *task_id, int event, void *arg, char **err) {
             ret = asmCreateImportTask(task_id, arg, &errsds) ? C_OK : C_ERR;
             break;
         case ASM_EVENT_CANCEL:
-            num_cancelled = clusterAsmCancel(task_id);
+            num_cancelled = clusterAsmCancel(task_id, "user request");
             if (arg) *((int *)arg) = num_cancelled;
             ret = C_OK;
             break;

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -2053,7 +2053,7 @@ int clusterAsmCancelBySlotRangeArray(struct slotRangeArray *slot_ranges, const c
     return num_cancelled;
 }
 
-/* Check if the slot is in an ASM task. */
+/* Check if the slot is in an active ASM task. */
 int isSlotInAsmTask(int slot) {
     slotRange req = {slot, slot};
     if (!asmManager) return 0;

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -422,7 +422,7 @@ static asmTask *lookupAsmTaskBySlotRange(slotRange *req) {
  *
  * Returns the source node if validation succeeds.
  * Otherwise, returns NULL and sets 'err' variable. */
-static clusterNode *validateImportSlotRanges(slotRangeArray *slot_ranges, sds *err) {
+static clusterNode *validateImportSlotRanges(slotRangeArray *slot_ranges, sds *err, asmTask *current) {
     clusterNode *source = NULL;
     unsigned char *slots = zcalloc(CLUSTER_SLOTS);
 
@@ -430,7 +430,7 @@ static clusterNode *validateImportSlotRanges(slotRangeArray *slot_ranges, sds *e
 
     /* Ensure this is a master node */
     if (!clusterNodeIsMaster(getMyClusterNode())) {
-        *err = sdsnew("Slot migration not allowed on replica.");
+        *err = sdsnew("slot migration not allowed on replica.");
         goto out;
     }
 
@@ -439,7 +439,7 @@ static clusterNode *validateImportSlotRanges(slotRangeArray *slot_ranges, sds *e
         if (getImportingSlotSource(i) != NULL ||
             getMigratingSlotDest(i) != NULL)
         {
-            *err = sdsnew("All slot states must be STABLE to start a slot migration task.");
+            *err = sdsnew("all slot states must be STABLE to start a slot migration task.");
             goto out;
         }
     }
@@ -447,9 +447,10 @@ static clusterNode *validateImportSlotRanges(slotRangeArray *slot_ranges, sds *e
     for (int i = 0; i < slot_ranges->num_ranges; i++) {
         slotRange *sr = &slot_ranges->ranges[i];
 
-        /* Ensure no import task overlaps with this slot range. */
+        /* Ensure no import task overlaps with this slot range.
+         * Skip check current task that is running for this slot range. */
         asmTask *task = lookupAsmTaskBySlotRange(sr);
-        if (task && task->operation == ASM_IMPORT) {
+        if (task && task != current && task->operation == ASM_IMPORT) {
             *err = sdscatprintf(sdsempty(),
                                 "overlapping import exists for slot range: %d-%d",
                                 sr->start, sr->end);
@@ -551,7 +552,7 @@ asmTask *asmCreateImportTask(const char *task_id, slotRangeArray *slot_ranges, s
     *err = NULL;
     /* Validate that the slot ranges are valid and that migration can be
      * initiated for them. */
-    source = validateImportSlotRanges(slot_ranges, err);
+    source = validateImportSlotRanges(slot_ranges, err, NULL);
     if (!source)
         return NULL;
 
@@ -819,6 +820,9 @@ void asmTaskSetFailed(asmTask *task, const char *fmt, ...) {
 void asmTaskComplete(asmTask *task) {
     listNode *ln = listFirst(asmManager->tasks);
     serverAssert(ln->value == task);
+
+    /* Should never access it */
+    task->source_node = NULL;
 
     task->done_time = server.mstime;
     asmManager->total_done_tasks++;
@@ -1203,7 +1207,7 @@ void asmSyncWithSource(connection *conn) {
         connSetPrivateData(task->rdb_channel_conn, task);
         serverLog(LL_NOTICE,
             "RDB channel connection to source node %.40s established, waiting for AUTH reply...",
-            clusterNodeGetName(task->source_node));
+            task->source);
 
         /* Main channel waits for the new event */
         connSetReadHandler(conn, NULL);
@@ -1333,8 +1337,36 @@ void clusterSyncSlotsStreamEOF(client *c) {
 /* Start the import task. */
 void asmStartImportTask(asmTask *task) {
     if (task->operation != ASM_IMPORT || task->state != ASM_NONE) return;
-
     sds slot_ranges_str = slotRangeArrayToString(task->slot_ranges);
+
+    /* Detect if the cluster topology is change. We should cancel the task if we can
+     * not schedule it, and update the source node if needed. */
+    sds err = NULL;
+    clusterNode *source = validateImportSlotRanges(task->slot_ranges, &err, task);
+    if (!source) {
+        serverLog(LL_WARNING, "Cancel the import task for slots: %s, occur error: %s",
+                              slot_ranges_str, err);
+        asmTaskCancel(task, "cluster topology changed");
+        sdsfree(slot_ranges_str);
+        sdsfree(err);
+        return;
+    }
+    /* Now I'm the owner of the slot range, cancel the import task. */
+    if (source == getMyClusterNode()) {
+        serverLog(LL_NOTICE, "Cancel the import task for slots: %s, since this node is"
+                             " already the owner of the slot range", slot_ranges_str);
+        asmTaskCancel(task, "slots owned by myselef");
+        sdsfree(slot_ranges_str);
+        return;
+    }
+    /* Change the source node if needed. */
+    if (source != task->source_node) {
+        task->source_node = source;
+        memcpy(task->source, source->name, CLUSTER_NAMELEN);
+        serverLog(LL_NOTICE, "Import slots %s task source node changed to %.40s",
+                             slot_ranges_str, source->name);
+    }
+
     serverLog(LL_NOTICE, "Import task starting: src=%.40s, dest=%.40s, slots=%s",
               task->source, task->dest, slot_ranges_str);
     sdsfree(slot_ranges_str);
@@ -1367,11 +1399,22 @@ void clusterSyncSlotsCommand(client *c) {
      * external clients may damage the slot migration state. */
     if (!(c->flags & (CLIENT_INTERNAL | CLIENT_MASTER))) {
         addReplyError(c, "CLUSTER SYNCSLOTS subcommands are only allowed for internal clients");
+        c->flags |= CLIENT_CLOSE_AFTER_REPLY;
         return;
     }
 
-    /* Only allow CONF subcommand on replica. */
-    if (server.masterhost && strcasecmp(c->argv[2]->ptr, "conf")) return;
+    /* On replica, only allow master client to execute CONF subcommand. */
+    if (server.masterhost) {
+        if (!(c->flags & CLIENT_MASTER)) {
+            /* Not master client, reject all subcommands and close the connection. */
+            addReplyError(c, "CLUSTER SYNCSLOTS subcommands are only allowed for master");
+            c->flags |= CLIENT_CLOSE_AFTER_REPLY;
+            return;
+        } else {
+            /* Only allow CONF subcommand on replica. */
+            if (strcasecmp(c->argv[2]->ptr, "conf")) return;
+        }
+    }
 
     if (!strcasecmp(c->argv[2]->ptr, "ranges") && c->argc >= 6) {
         /* CLUSTER SYNCSLOTS RANGES <ID> <start-slot> <end-slot> [<start-slot> <end-slot>] */
@@ -1386,7 +1429,7 @@ void clusterSyncSlotsCommand(client *c) {
         /* Validate that the slot ranges are valid and that migration can be
          * initiated for them. */
         sds err = NULL;
-        clusterNode *source = validateImportSlotRanges(slot_ranges, &err);
+        clusterNode *source = validateImportSlotRanges(slot_ranges, &err, NULL);
         if (!source) {
             addReplyErrorSds(c, err);
             zfree(slot_ranges);

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -108,6 +108,7 @@ void createDumpPayload(rio *payload, robj *o, robj *key, int dbid);
 int startBgsaveForReplication(int mincapa, int req);
 void createReplicationBacklogIfNeeded(void);
 static void asmSyncBufferReadFromConn(connection *conn);
+static void asmTaskCancel(asmTask *task, const char *reason);
 
 void clusterAsmInit(void) {
     asmManager = zcalloc(sizeof(*asmManager));
@@ -561,10 +562,20 @@ asmTask *asmCreateImportTask(const char *task_id, slotRangeArray *slot_ranges, s
         return NULL;
     }
 
+    /* Only support a single task at a time now. */
     if (listLength(asmManager->tasks) != 0) {
-        *err = sdsnew("another ASM task is already in progress");
-        return NULL;
+        asmTask *current = listNodeValue(listFirst(asmManager->tasks));
+        if (current->state == ASM_FAILED) {
+            /* We can create a new task only if the current one is failed,
+             * cancel the failed task to create a new one. */
+            asmTaskCancel(current, "new task requested");
+        } else {
+            *err = sdsnew("another ASM task is already in progress");
+            return NULL;
+        }
     }
+    /* There should be no task in progress. */
+    serverAssert(listLength(asmManager->tasks) == 0);
 
     /* Create a slot migration task */
     asmTask *task = asmTaskCreate(task_id);
@@ -844,7 +855,7 @@ void asmTaskComplete(asmTask *task) {
     }
 }
 
-void asmTaskCancel(asmTask *task, const char *reason) {
+static void asmTaskCancel(asmTask *task, const char *reason) {
     if (task->state == ASM_CANCELED) return;
 
     asmTaskSetFailed(task, "Cancelled due to %s", reason);
@@ -1458,7 +1469,8 @@ void clusterSyncSlotsCommand(client *c) {
             task->retry_count++;
         } else if (task) {
             if (task->state == ASM_FAILED) {
-                /* Cancel the failed task, and create new one. */
+                /* We can create a new task only if the current one is failed,
+                 * cancel the failed task to create a new one. */
                 asmTaskCancel(task, "new task requested");
                 task = NULL;
             } else {
@@ -2041,6 +2053,22 @@ int clusterAsmCancelBySlotRangeArray(struct slotRangeArray *slot_ranges, const c
     return num_cancelled;
 }
 
+/* Check if the slot is in an ASM task. */
+int isSlotInAsmTask(int slot) {
+    slotRange req = {slot, slot};
+    if (!asmManager) return 0;
+
+    listIter li;
+    listNode *ln;
+    listRewind(asmManager->tasks, &li);
+    while ((ln = listNext(&li)) != NULL) {
+        asmTask *task = listNodeValue(ln);
+        if (slotRangeArrayOverlaps(task->slot_ranges, &req))
+            return 1;
+    }
+    return 0;
+}
+
 int clusterAsmHandoff(const char *task_id, sds *err) {
     serverAssert(task_id);
 
@@ -2057,15 +2085,22 @@ int clusterAsmHandoff(const char *task_id, sds *err) {
     return C_OK;
 }
 
-int asmNotifyConfigUpdated(slotRangeArray *slot_ranges, sds *err) {
-    /* TODO: Validation, cancel asmTasks if required */
-
+/* Notify Redis that the config is updated for the given slot ranges.
+ * If `current` is provided, it should match the task found for the slot ranges.
+ * If `current` is NULL, any task found will be used, if no task is found, it means
+ * the config update is not related to current ASM task, but this node learned about
+ * the config update from cluster protocol, and we need to cancel any conflicting
+ * tasks that overlap with the slot ranges. */
+int asmNotifyConfigUpdated(asmTask *current, slotRangeArray *slot_ranges, sds *err) {
     asmTask *task = lookupAsmTaskBySlotRangeArray(slot_ranges);
+    if (current != NULL) serverAssert(task == current);
     if (!task) {
-        sds slot_ranges_str = slotRangeArrayToString(slot_ranges);
-        *err = sdscatprintf(sdsempty(), "No ASM task found for slots: %s", slot_ranges_str);
-        sdsfree(slot_ranges_str);
-        return C_ERR;
+        /* Cancel asmTasks that overlap with the slot ranges, since the cluster topology
+         * has changed. That may be because another node with different slot config and
+         * higher configEpoch takes over the slot ranges, e.g., a slot is updated through
+         * CLUSTER SETSLOT <slot> NODE <node-id> directly. */
+        clusterAsmCancelBySlotRangeArray(slot_ranges, "cluster topology changed");
+        return C_OK;
     }
 
     if (task->operation == ASM_IMPORT && task->state == ASM_TAKEOVER) {
@@ -2085,6 +2120,9 @@ int asmNotifyConfigUpdated(slotRangeArray *slot_ranges, sds *err) {
         *err = sdscatprintf(sdsempty(),
                             "ASM task is not in the correct state for config update: %s",
                             asmTaskStateToString(task->state));
+        /* Cancel asmTasks that overlap with the slot ranges, since the cluster topology
+         * has changed and the task is not in the correct state to complete. */
+        clusterAsmCancelBySlotRangeArray(slot_ranges, "cluster topology changed");
         return C_ERR;
     }
 
@@ -2100,7 +2138,7 @@ int clusterAsmDone(const char *task_id, sds *err) {
         *err = sdscatprintf(sdsempty(), "No ASM task found for id: %s", task_id);
         return C_ERR;
     }
-    return asmNotifyConfigUpdated(task->slot_ranges, err);
+    return asmNotifyConfigUpdated(task, task->slot_ranges, err);
 }
 
 int clusterAsmProcess(const char *task_id, int event, void *arg, char **err) {

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -108,8 +108,6 @@ void createDumpPayload(rio *payload, robj *o, robj *key, int dbid);
 int startBgsaveForReplication(int mincapa, int req);
 void createReplicationBacklogIfNeeded(void);
 static void asmSyncBufferReadFromConn(connection *conn);
-void asmTaskSetFailed(asmTask *task, const char *fmt, ...);
-int clusterAsmCancel(const char *task_id);
 
 void clusterAsmInit(void) {
     asmManager = zcalloc(sizeof(*asmManager));
@@ -300,6 +298,26 @@ int asmKeyBelongsToCurrentNode(kvobj *kv) {
     return 1;
 }
 
+size_t asmGetImportingBufferSize(void) {
+    if (!asmManager || listLength(asmManager->tasks) == 0) return 0;
+
+    asmTask *task = listNodeValue(listFirst(asmManager->tasks));
+    if (task->operation == ASM_IMPORT)
+        return task->sync_buffer.mem_used;
+
+    return 0;
+}
+
+size_t asmGetMigratingBufferSize(void) {
+    if (!asmManager || listLength(asmManager->tasks) == 0) return 0;
+
+    asmTask *task = listNodeValue(listFirst(asmManager->tasks));
+    if (task->operation == ASM_MIGRATE && task->main_channel_client)
+        return getClientOutputBufferMemoryUsage(task->main_channel_client);
+
+    return 0;
+}
+
 static int compareSlotRange(const void *a, const void *b) {
     const slotRange *sa = a;
     const slotRange *sb = b;
@@ -367,6 +385,15 @@ static int slotRangeArrayOverlaps(slotRangeArray *sra, slotRange *req) {
         slotRange *sr = &sra->ranges[i];
         if (sr->start <= req->end && sr->end >= req->start)
             return 1;
+    }
+    return 0;
+}
+
+/* Returns 1 if the two slot range arrays overlap, 0 otherwise. */
+static int slotRangeArraysOverlap(slotRangeArray *sra1, slotRangeArray *sra2) {
+    for (int i = 0; i < sra1->num_ranges; i++) {
+        slotRange *sr1 = &sra1->ranges[i];
+        if (slotRangeArrayOverlaps(sra2, sr1)) return 1;
     }
     return 0;
 }
@@ -972,7 +999,7 @@ void asmRdbChannelSyncWithSource(connection *conn) {
 
             task->rdb_channel_state = ASM_RDBCHANNEL_TRANSFER;
             client *c = createClient(conn);
-            c->flags |= (CLIENT_MASTER | CLIENT_INTERNAL);
+            c->flags |= (CLIENT_MASTER | CLIENT_INTERNAL | CLIENT_ASM_IMPORTING);
             c->querybuf = sdsempty();
             c->authenticated = 1;
             c->user = NULL;
@@ -1380,9 +1407,15 @@ void clusterSyncSlotsCommand(client *c) {
             zfree(task->slot_ranges); /* Will be set again later */
             task->retry_count++;
         } else if (task) {
-            addReplyError(c, "Another migration task is already in progress");
-            zfree(slot_ranges);
-            return;
+            if (task->state == ASM_FAILED) {
+                /* Cancel the failed task, and create new one. */
+                asmTaskCancel(task);
+                task = NULL;
+            } else {
+                addReplyError(c, "Another migration task is already in progress");
+                zfree(slot_ranges);
+                return;
+            }
         }
 
         /* Create the migrate slots task and add it to the list,
@@ -1390,6 +1423,7 @@ void clusterSyncSlotsCommand(client *c) {
         if (task == NULL) {
             task = asmTaskCreate(task_id);
             task->start_time = server.mstime; /* Start immediately */
+            serverAssert(listLength(asmManager->tasks) == 0);
             listAddNodeTail(asmManager->tasks, task);
         }
 
@@ -1398,19 +1432,13 @@ void clusterSyncSlotsCommand(client *c) {
         memcpy(task->source, getMyClusterNode()->name, CLUSTER_NAMELEN);
         if (c->node_id) memcpy(task->dest, c->node_id, CLUSTER_NAMELEN);
 
-        clusterNode *dst = clusterLookupNode(task->dest, CLUSTER_NAMELEN);
-        if (dst) {
-            int port = server.tls_replication ? dst->tls_port : dst->tcp_port;
-            c->slave_listening_port = port;
-        }
-
         task->main_channel_client = c;
         c->task = task;
 
         /* We mark the main channel client as a replica, so this client is limited
          * by the client output buffer settings for replicas. The replstate has no
          * real significance, just to prevent it from going online. */
-        c->flags |= (CLIENT_SLAVE | CLIENT_REPL_MIGRATION_DEST);
+        c->flags |= (CLIENT_SLAVE | CLIENT_ASM_MIGRATING);
         c->replstate = SLAVE_STATE_WAIT_RDB_CHANNEL;
         if (server.repl_disable_tcp_nodelay)
             connDisableTcpNoDelay(c->conn);  /* Non critical if it fails. */
@@ -1465,12 +1493,11 @@ void clusterSyncSlotsCommand(client *c) {
         }
 
         /* Mark the client as a slave to generate slots snapshot */
-        c->flags |= (CLIENT_SLAVE | CLIENT_REPL_RDB_CHANNEL | CLIENT_REPL_RDBONLY | CLIENT_REPL_MIGRATION_DEST);
+        c->flags |= (CLIENT_SLAVE | CLIENT_REPL_RDB_CHANNEL | CLIENT_REPL_RDBONLY | CLIENT_ASM_MIGRATING);
         c->slave_capa |= SLAVE_CAPA_EOF;
         c->slave_req |= (SLAVE_REQ_SLOTS_SNAPSHOT | SLAVE_REQ_RDB_CHANNEL);
         c->replstate = SLAVE_STATE_WAIT_BGSAVE_START;
         c->repldbfd = -1;
-        c->slave_listening_port = task->main_channel_client->slave_listening_port;
         if (server.repl_disable_tcp_nodelay)
             connDisableTcpNoDelay(c->conn); /* Non critical if it fails. */
         listAddNodeTail(server.slaves, c);
@@ -1791,7 +1818,7 @@ void asmSyncBufferStreamToDb(asmTask *task) {
     /* The buffered stream from the main channel connection into
      * the database is processed by a fake client. */
     client *c = createClient(task->main_channel_conn);
-    c->flags |= (CLIENT_MASTER | CLIENT_INTERNAL);
+    c->flags |= (CLIENT_MASTER | CLIENT_INTERNAL | CLIENT_ASM_IMPORTING);
     c->querybuf = sdsempty();
     c->authenticated = 1;
     c->user = NULL;
@@ -1922,6 +1949,8 @@ void asmCron(void) {
 
 /* Cancel a specific task if ID is provided, otherwise cancel all tasks. */
 int clusterAsmCancel(const char *task_id) {
+    if (asmManager == NULL) return 0;
+
     if (task_id) {
         asmTask *task = lookupAsmTaskById(task_id);
         if (!task) return 0; /* Not found */
@@ -1941,6 +1970,25 @@ int clusterAsmCancel(const char *task_id) {
         }
         return num_cancelled;
     }
+}
+
+/* Cancel all tasks that overlap with the given slot ranges.
+ * If slot_ranges is NULL, cancel all tasks. */
+int clusterAsmCancelBySlotRangeArray(struct slotRangeArray *slot_ranges) {
+    if (asmManager == NULL) return 0;
+
+    int num_cancelled = 0;
+    listIter li;
+    listNode *ln;
+    listRewind(asmManager->tasks, &li);
+    while ((ln = listNext(&li)) != NULL) {
+        asmTask *task = listNodeValue(ln);
+        if (!slot_ranges || slotRangeArraysOverlap(task->slot_ranges, slot_ranges)) {
+            asmTaskCancel(task);
+            num_cancelled++;
+        }
+    }
+    return num_cancelled;
 }
 
 int clusterAsmHandoff(const char *task_id, sds *err) {

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -990,11 +990,12 @@ void asmRdbChannelSyncWithSource(connection *conn) {
 
     if (task->rdb_channel_state == ASM_RDBCHANNEL_REPLY) {
         err = receiveSynchronousResponse(conn);
-        /* The destination node did not reply */
+        /* The source node did not reply */
         if (err == NULL) goto no_response_error;
 
-        /* Ignore `\n` that may be sent to keep the connection alive */
+        /* Ignore ‘\n' sent from the source node to keep the connection alive. */
         if (sdslen(err) == 0) {
+            serverLog(LL_DEBUG, "Received an empty line in RDBCHANNEL reply, slots snapshot delivery will start later");
             sdsfree(err);
             return;
         }
@@ -1355,7 +1356,7 @@ void asmStartImportTask(asmTask *task) {
     if (source == getMyClusterNode()) {
         serverLog(LL_NOTICE, "Cancel the import task for slots: %s, since this node is"
                              " already the owner of the slot range", slot_ranges_str);
-        asmTaskCancel(task, "slots owned by myselef");
+        asmTaskCancel(task, "slots owned by myself");
         sdsfree(slot_ranges_str);
         return;
     }

--- a/src/cluster_asm.h
+++ b/src/cluster_asm.h
@@ -28,8 +28,8 @@ size_t asmGetPeakSyncBufferSize(void);
 int asmKeyBelongsToCurrentNode(kvobj *kv);
 size_t asmGetImportingBufferSize(void);
 size_t asmGetMigratingBufferSize(void);
-int clusterAsmCancel(const char *task_id);
-int clusterAsmCancelBySlotRangeArray(struct slotRangeArray *slot_ranges);
+int clusterAsmCancel(const char *task_id, const char *reason);
+int clusterAsmCancelBySlotRangeArray(struct slotRangeArray *slot_ranges, const char *reason);
 
 void clusterMigrationCommand(client *c);
 void clusterSyncSlotsCommand(client *c);

--- a/src/cluster_asm.h
+++ b/src/cluster_asm.h
@@ -26,6 +26,10 @@ struct slotRangeArray *asmTaskGetSlotRanges(const char *task_id);
 int asmNotifyConfigUpdated(struct slotRangeArray *slot_ranges, sds *err);
 size_t asmGetPeakSyncBufferSize(void);
 int asmKeyBelongsToCurrentNode(kvobj *kv);
+size_t asmGetImportingBufferSize(void);
+size_t asmGetMigratingBufferSize(void);
+int clusterAsmCancel(const char *task_id);
+int clusterAsmCancelBySlotRangeArray(struct slotRangeArray *slot_ranges);
 
 void clusterMigrationCommand(client *c);
 void clusterSyncSlotsCommand(client *c);

--- a/src/cluster_asm.h
+++ b/src/cluster_asm.h
@@ -23,13 +23,14 @@ void asmFeedMigrationClient(robj **argv, int argc);
 int asmDebugSetFailPoint(char * channel, char *state);
 void asmImportIncrAppliedBytes(struct asmTask *task, size_t bytes);
 struct slotRangeArray *asmTaskGetSlotRanges(const char *task_id);
-int asmNotifyConfigUpdated(struct slotRangeArray *slot_ranges, sds *err);
+int asmNotifyConfigUpdated(struct asmTask *task, struct slotRangeArray *slot_ranges, sds *err);
 size_t asmGetPeakSyncBufferSize(void);
 int asmKeyBelongsToCurrentNode(kvobj *kv);
 size_t asmGetImportingBufferSize(void);
 size_t asmGetMigratingBufferSize(void);
 int clusterAsmCancel(const char *task_id, const char *reason);
 int clusterAsmCancelBySlotRangeArray(struct slotRangeArray *slot_ranges, const char *reason);
+int isSlotInAsmTask(int slot);
 
 void clusterMigrationCommand(client *c);
 void clusterSyncSlotsCommand(client *c);

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2448,7 +2448,7 @@ void clusterUpdateSlotsConfigWith(clusterNode *sender, uint64_t senderConfigEpoc
     }
     if (sra->num_ranges > 0 && server.masterhost == NULL) {
         sds err = NULL;
-        if (asmNotifyConfigUpdated(sra, &err) != C_OK) {
+        if (asmNotifyConfigUpdated(NULL, sra, &err) != C_OK) {
             serverLog(LL_WARNING, "ASM config update failed: %s", err);
             sdsfree(err);
         }
@@ -6099,6 +6099,14 @@ int clusterCommandSpecial(client *c) {
         }
 
         if ((slot = getSlotOrReply(c, c->argv[2])) == -1) return 1;
+
+        /* Don't allow old style slot migration if the slot is in an ASM task. */
+        if (isSlotInAsmTask(slot)) {
+            addReplyErrorFormat(c, "Slot %d is in an active atomic slot migration, "
+                "cannot use CLUSTER SETSLOT now, if you persist in using this command, "
+                "please use CLUSTER MIGRATION CANCEL to cancel the task first", slot);
+            return 1;
+        }
 
         if (!strcasecmp(c->argv[3]->ptr,"migrating") && c->argc == 5) {
             if (server.cluster->slots[slot] != myself) {

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1085,6 +1085,9 @@ void clusterReset(int hard) {
     clusterCloseAllSlots();
     resetManualFailover();
 
+    /* Cancel all ASM tasks */
+    clusterAsmCancel(NULL);
+
     /* Unassign all the slots. */
     for (j = 0; j < CLUSTER_SLOTS; j++) clusterDelSlot(j);
 
@@ -5318,6 +5321,7 @@ void clusterSetMaster(clusterNode *n) {
         myself->flags &= ~(CLUSTER_NODE_MASTER|CLUSTER_NODE_MIGRATE_TO);
         myself->flags |= CLUSTER_NODE_SLAVE;
         clusterCloseAllSlots();
+        clusterAsmCancel(NULL); /* Cancel all ASM tasks when turning into slave */
     } else {
         if (myself->slaveof)
             clusterNodeRemoveSlave(myself->slaveof,myself);

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1086,7 +1086,7 @@ void clusterReset(int hard) {
     resetManualFailover();
 
     /* Cancel all ASM tasks */
-    clusterAsmCancel(NULL);
+    clusterAsmCancel(NULL, "CLUSTER RESET");
 
     /* Unassign all the slots. */
     for (j = 0; j < CLUSTER_SLOTS; j++) clusterDelSlot(j);
@@ -5321,7 +5321,8 @@ void clusterSetMaster(clusterNode *n) {
         myself->flags &= ~(CLUSTER_NODE_MASTER|CLUSTER_NODE_MIGRATE_TO);
         myself->flags |= CLUSTER_NODE_SLAVE;
         clusterCloseAllSlots();
-        clusterAsmCancel(NULL); /* Cancel all ASM tasks when turning into slave */
+        /* Cancel all ASM tasks when switching into slave */
+        clusterAsmCancel(NULL, "switching to replica");
     } else {
         if (myself->slaveof)
             clusterNodeRemoveSlave(myself->slaveof,myself);

--- a/src/cluster_plugin.h
+++ b/src/cluster_plugin.h
@@ -113,8 +113,6 @@ typedef struct {
     clusterNodeTlsPortFunc clusterNodeTlsPort;
     clusterGetSecretFunc clusterGetSecret;
     clusterAsmOnEventFunc clusterAsmOnEvent;
-
-
 } ClusterPlugin;
 
 void clusterPluginInit(ClusterPlugin *plugin);

--- a/src/db.c
+++ b/src/db.c
@@ -1089,7 +1089,7 @@ int flushCommandCommon(client *c, int type, int flags, slotRangeArray *sra) {
     }
 
     /* Cancel all ASM tasks that overlap with the given slot ranges. */
-    clusterAsmCancelBySlotRangeArray(sra);
+    clusterAsmCancelBySlotRangeArray(sra, c->argv[0]->ptr);
 
     if (type == FLUSH_TYPE_ALL) {
         flushAllDataAndResetRDB(flags | EMPTYDB_NOFUNCTIONS);

--- a/src/db.c
+++ b/src/db.c
@@ -1088,6 +1088,9 @@ int flushCommandCommon(client *c, int type, int flags, slotRangeArray *sra) {
         blocking_async = 1;
     }
 
+    /* Cancel all ASM tasks that overlap with the given slot ranges. */
+    clusterAsmCancelBySlotRangeArray(sra);
+
     if (type == FLUSH_TYPE_ALL) {
         flushAllDataAndResetRDB(flags | EMPTYDB_NOFUNCTIONS);
     } else if (type == FLUSH_TYPE_DB) {

--- a/src/evict.c
+++ b/src/evict.c
@@ -470,9 +470,9 @@ static int isSafeToPerformEvictions(void) {
 
     /* Disable eviction during slot migration import to avoid delays and errors
      * caused by failed evictions. A special client is created for data import,
-     * identified by the CLIENT_MASTER flag and the presence of a `task` field. */
+     * identified by the CLIENT_MASTER and CLIENT_ASM_IMPORTING flags. */
     if (server.current_client && server.current_client->flags & CLIENT_MASTER &&
-        server.current_client->task)
+        server.current_client->flags & CLIENT_ASM_IMPORTING)
         return 0;
 
     /* If 'evict' action is paused, for whatever reason, then return false */

--- a/src/networking.c
+++ b/src/networking.c
@@ -562,8 +562,13 @@ void afterErrorReply(client *c, const char *s, size_t len, int flags) {
             to = "AOF-loading-client";
             from = "server";
         } else if (ctype == CLIENT_TYPE_MASTER) {
-            to = "master";
-            from = "replica";
+            if (c->flags & CLIENT_ASM_IMPORTING) {
+                to = "source";
+                from = "destination";
+            } else {
+                to = "master";
+                from = "replica";
+            }
         } else {
             to = "replica";
             from = "master";
@@ -580,6 +585,10 @@ void afterErrorReply(client *c, const char *s, size_t len, int flags) {
             showLatestBacklog();
         }
         server.stat_unexpected_error_replies++;
+
+        /* If there is an ASM import task in progress, we need to close the client
+         * to let this task fail. */
+        if (c->flags & CLIENT_ASM_IMPORTING) freeClientAsync(c);
 
         /* Based off the propagation error behavior, check if we need to panic here. There
          * are currently two checked cases:
@@ -2686,7 +2695,8 @@ void commandProcessed(client *c) {
             c->repl_applied += applied;
 
             /* Update the atomic slot migration task's applied bytes. */
-            if (c->task) asmImportIncrAppliedBytes(c->task, applied);
+            if (c->flags & CLIENT_ASM_MIGRATING)
+                asmImportIncrAppliedBytes(c->task, applied);
         }
     }
 }
@@ -3139,10 +3149,17 @@ sds catClientInfoString(sds s, client *client) {
     if (client->flags & CLIENT_SLAVE) {
         if (client->flags & CLIENT_MONITOR)
             *p++ = 'O';
+        else if (client->flags & CLIENT_ASM_MIGRATING)
+            *p++ = 'm';
         else
             *p++ = 'S';
     }
-    if (client->flags & CLIENT_MASTER) *p++ = 'M';
+    if (client->flags & CLIENT_MASTER) {
+        if (client->flags & CLIENT_ASM_IMPORTING)
+            *p++ = 'i';
+        else
+            *p++ = 'M';
+    }
     if (client->flags & CLIENT_PUBSUB) *p++ = 'P';
     if (client->flags & CLIENT_MULTI) *p++ = 'x';
     if (client->flags & CLIENT_BLOCKED) *p++ = 'b';
@@ -4249,7 +4266,7 @@ static inline int clientTypeIsSlave(client *c) {
     /* Even though MONITOR clients and ASM destination RDB/main channels are marked
      * as replicas, we want the expose them as normal clients. */
     if (unlikely((c->flags & CLIENT_SLAVE) &&
-        !(c->flags & (CLIENT_MONITOR | CLIENT_REPL_MIGRATION_DEST))))
+        !(c->flags & (CLIENT_MONITOR | CLIENT_ASM_MIGRATING))))
     {
         return 1;
     }

--- a/src/networking.c
+++ b/src/networking.c
@@ -586,10 +586,6 @@ void afterErrorReply(client *c, const char *s, size_t len, int flags) {
         }
         server.stat_unexpected_error_replies++;
 
-        /* If there is an ASM import task in progress, we need to close the client
-         * to let this task fail. */
-        if (c->flags & CLIENT_ASM_IMPORTING) freeClientAsync(c);
-
         /* Based off the propagation error behavior, check if we need to panic here. There
          * are currently two checked cases:
          * * If this command was from our master and we are not a writable replica.

--- a/src/object.c
+++ b/src/object.c
@@ -14,6 +14,7 @@
 #include "server.h"
 #include "functions.h"
 #include "intset.h"  /* Compact integer set structure */
+#include "cluster_asm.h"
 #include <math.h>
 #include <ctype.h>
 
@@ -1502,6 +1503,12 @@ struct redisMemOverhead *getMemoryOverheadData(void) {
         net_usage = zmalloc_used - mh->startup_allocated;
     mh->dataset_perc = (float)mh->dataset*100/net_usage;
     mh->bytes_per_key = mh->total_keys ? (mh->dataset / mh->total_keys) : 0;
+
+    /* Cluster atomic slot migration buffers. */
+    mh->asm_importing_buffer = asmGetImportingBufferSize();
+    mh->asm_migrating_buffer = asmGetMigratingBufferSize();
+    mem_total += mh->asm_importing_buffer;
+    mem_total += mh->asm_migrating_buffer;
 
     return mh;
 }

--- a/src/replication.c
+++ b/src/replication.c
@@ -249,7 +249,7 @@ int canFeedReplicaReplBuffer(client *replica) {
     /* Don't feed replicas that only want the RDB or main channels of migration
      * destinations which need filtered stream for migrating slot ranges. */
     if (replica->flags & CLIENT_REPL_RDBONLY ||
-        replica->flags & CLIENT_REPL_MIGRATION_DEST) return 0;
+        replica->flags & CLIENT_ASM_MIGRATING) return 0;
 
     /* Don't feed replicas that are still waiting for BGSAVE to start. */
     if (replica->replstate == SLAVE_STATE_WAIT_BGSAVE_START ||
@@ -1478,7 +1478,7 @@ int replicaPutOnline(client *slave) {
     }
 
     /* Don't put migration destination client online. */
-    if (slave->flags & CLIENT_REPL_MIGRATION_DEST) return 0;
+    if (slave->flags & CLIENT_ASM_MIGRATING) return 0;
 
     slave->replstate = SLAVE_STATE_ONLINE;
     slave->repl_ack_time = server.unixtime; /* Prevent false timeout. */

--- a/src/server.c
+++ b/src/server.c
@@ -4620,6 +4620,7 @@ int isReadyToShutdown(void) {
     listRewind(server.slaves, &li);
     while ((ln = listNext(&li)) != NULL) {
         client *replica = listNodeValue(ln);
+        /* Don't count migration destination replicas. */
         if (replica->flags & CLIENT_ASM_MIGRATING) continue;
         if (replica->repl_ack_off != server.master_repl_offset) return 0;
     }
@@ -4667,6 +4668,8 @@ int finishShutdown(void) {
     listRewind(server.slaves, &replicas_iter);
     while ((replicas_list_node = listNext(&replicas_iter)) != NULL) {
         client *replica = listNodeValue(replicas_list_node);
+        /* Don't count migration destination replicas. */
+        if (replica->flags & CLIENT_ASM_MIGRATING) continue;
         num_replicas++;
         if (replica->repl_ack_off != server.master_repl_offset) {
             num_lagging_replicas++;

--- a/src/server.c
+++ b/src/server.c
@@ -4620,7 +4620,7 @@ int isReadyToShutdown(void) {
     listRewind(server.slaves, &li);
     while ((ln = listNext(&li)) != NULL) {
         client *replica = listNodeValue(ln);
-        if (replica->flags & CLIENT_REPL_MIGRATION_DEST) continue;
+        if (replica->flags & CLIENT_ASM_MIGRATING) continue;
         if (replica->repl_ack_off != server.master_repl_offset) return 0;
     }
     return 1;
@@ -6009,6 +6009,8 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
             "allocator_rss_bytes:%zd\r\n", mh->allocator_rss_bytes,
             "rss_overhead_ratio:%.2f\r\n", mh->rss_extra,
             "rss_overhead_bytes:%zd\r\n", mh->rss_extra_bytes,
+            "asm_migrating_buffer:%zu\r\n", mh->asm_migrating_buffer,
+            "asm_importing_buffer:%zu\r\n", mh->asm_importing_buffer,
             /* The next field (mem_fragmentation_ratio) is the total RSS
              * overhead, including fragmentation, but not just it. This field
              * (and the next one) is named like that just for backward
@@ -6327,6 +6329,10 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
                  * replica has an associated main-channel replica in
                  * server.slaves list, we'll list main channel replica only. */
                 if (replicationCheckHasMainChannel(slave))
+                    continue;
+
+                /* Don't list migration destination replicas. */
+                if (slave->flags & CLIENT_ASM_MIGRATING)
                     continue;
 
                 if (!slaveip) {

--- a/src/server.h
+++ b/src/server.h
@@ -427,7 +427,8 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
 #define CLIENT_REPROCESSING_COMMAND (1ULL<<50) /* The client is re-processing the command. */
 #define CLIENT_REPL_RDB_CHANNEL (1ULL<<51)      /* Client which is used for rdb delivery as part of rdb channel replication */
 #define CLIENT_INTERNAL (1ULL<<52) /* Internal client connection */
-#define CLIENT_REPL_MIGRATION_DEST (1ULL<<53) /* Client is a main channel for atomic slot migration destination */
+#define CLIENT_ASM_MIGRATING (1ULL<<53) /* Client is migrating RDB/stream data during atomic slot migration. */
+#define CLIENT_ASM_IMPORTING (1ULL<<54) /* Client is importing RDB/stream data during atomic slot migration. */
 
 /* Any flag that does not let optimize FLUSH SYNC to run it in bg as blocking client ASYNC */
 #define CLIENT_AVOID_BLOCKING_ASYNC_FLUSH (CLIENT_DENY_BLOCKING|CLIENT_MULTI|CLIENT_LUA_DEBUG|CLIENT_LUA_DEBUG_SYNC|CLIENT_MODULE)
@@ -1629,6 +1630,8 @@ struct redisMemOverhead {
     size_t overhead_db_hashtable_lut;
     size_t overhead_db_hashtable_rehashing;
     unsigned long db_dict_rehashing_count;
+    size_t asm_importing_buffer;
+    size_t asm_migrating_buffer;
     struct {
         size_t dbid;
         size_t overhead_ht_main;

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -505,6 +505,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         # we set a delay to failover
         R 1 config set rdb-key-save-delay 1000000
 
+        # migrate slot 0-100 from 1 to 0
         set task_id [R 0 CLUSTER MIGRATION IMPORT 0 100]
         wait_for_condition 2000 10 {
             [string match {*send-bulk-and-stream*} [migration_status 1 $task_id state]]
@@ -512,16 +513,16 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
             fail "ASM task did not start"
         }
 
-        # FAILOVER to instance #3
-        R 3 cluster failover force
+        # FAILOVER happens on the destination node, instance #3 become master, #0 become slave
+        R 3 cluster failover
         wait_for_condition 1000 50 {
             [getInfoProperty [R 3 info] role] eq {master}
         } else {
             fail "Instance #3 is not a master after some time"
         }
 
-        # If a failover happens, the old master will cancel ASM task,
-        # and ASM task on another side of slot migration will be failed
+        # the old master will cancel the importing task, and the migrating task on
+        # the source node will be failed
         wait_for_condition 1000 50 {
             [string match {*canceled*} [migration_status 0 $task_id state]] &&
             [string match {*failed*} [migration_status 1 $task_id state]]
@@ -529,7 +530,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
             fail "ASM task did not cancel"
         }
 
-        # We can restart ASM tasks on new master
+        # We can restart ASM tasks on new master, migrate slot 0-100 from 1 to 3
         R 1 config set rdb-key-save-delay 0
         set task_id [R 3 CLUSTER MIGRATION IMPORT 0 100]
         wait_for_condition 1000 50 {
@@ -539,42 +540,65 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
             fail "ASM task did not finish"
         }
 
-        # FAILOVER back to instance #2
-        R 0 cluster failover force
+        # migrate slot 0-100 from 3 to 1
+        R 3 config set rdb-key-save-delay 1000000
+        set task_id [R 1 CLUSTER MIGRATION IMPORT 0 100]
+        wait_for_condition 2000 10 {
+            [string match {*send-bulk-and-stream*} [migration_status 3 $task_id state]]
+        } else {
+            fail "ASM task did not start"
+        }
+
+        # FAILOVER happens on the source node, instance #3 become slave, #0 become master
+        R 0 cluster failover
         wait_for_condition 1000 50 {
             [getInfoProperty [R 0 info] role] eq {master}
         } else {
             fail "Instance #0 is not a master after some time"
         }
+
+        # the old master will cancel the migrating task, but the destination node will
+        # retry the importing task, and then succeed.
+        wait_for_condition 1000 50 {
+            [string match {*canceled*} [migration_status 3 $task_id state]]
+        } else {
+            fail "ASM task did not cancel"
+        }
+        wait_for_condition 1000 50 {
+            [string match {*done*} [migration_status 1 $task_id state]] &&
+            [string match {*done*} [migration_status 0 $task_id state]]
+        } else {
+            fail "ASM task did not finish"
+        }
     }
 
     test "Flush-like command can cancel slot migration task" {
         # we set a delay to cancel
-        R 0 config set rdb-key-save-delay 1000000
+        R 1 config set rdb-key-save-delay 1000000
 
         # flushall, flushdb, sflush
         foreach flushcmd {flushall flushdb sflush} {
             # write some keys on R 0
             set slot0_key "06S"
             set slot1_key "Qi"
-            R 0 set $slot0_key "a"
-            R 0 set $slot1_key "b"
+            R 1 set $slot0_key "a"
+            R 1 set $slot1_key "b"
 
-            # start slot migration
-            set task_id [R 1 CLUSTER MIGRATION IMPORT 0 100]
-            wait_for_condition 1000 50 {
-                [string match {*send-bulk-and-stream*} [migration_status 0 $task_id state]]
+            # start slot migration from 1 to 0
+            set task_id [R 0 CLUSTER MIGRATION IMPORT 0 100]
+            wait_for_condition 1000 20 {
+                [string match {*send-bulk-and-stream*} [migration_status 1 $task_id state]]
             } else {
                 fail "ASM task did not start"
             }
 
             if {$::verbose} { puts "flush command: $flushcmd"}
             if {$flushcmd == "flushall"} {
-                R 1 flushall
+                R 0 flushall
             } elseif {$flushcmd == "flushdb"} {
-                R 1 flushdb
+                R 0 flushdb
             } elseif {$flushcmd == "sflush"} {
-                R 0 sflush 10 110
+                R 1 sflush 10 110
             }
 
             # flush-like will cancel the task
@@ -586,8 +610,10 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
             }
         }
 
-        # 0-100 migration will be successful
-        R 0 config set rdb-key-save-delay 0
+        # Since sflush is executed on the source, the task is only canceled on the source.
+        # The destination node will retry the import task, and eventually the slot 0-100
+        # migration will succeed.
+        R 1 config set rdb-key-save-delay 0
         wait_for_condition 1000 50 {
             [string match {*done*} [migration_status 0 $task_id state]] &&
             [string match {*done*} [migration_status 1 $task_id state]]

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -656,7 +656,12 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
             assert_match {*in an active atomic slot migration*} $err
         }
 
-        # CLUSTER SETSLOT on other node will cancel the migration task
+        # CLUSTER SETSLOT on other node will cancel the migration task, we update
+        # the owner of slot 0 (that is migrating from #0 to #1) to #2 on #2, we
+        # bump the config epoch to make sure the change can update #0 and #1
+        # slot configuration, so #0 and #1 will cancel the migration task.
+        # BTW, if config epoch is not bumped, the slot config of #2 may be
+        # updated by #0 and #1.
         R 2 CLUSTER BUMPEPOCH
         R 2 cluster setslot 0 node [R 2 cluster myid]
         wait_for_condition 1000 50 {
@@ -666,7 +671,9 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
             fail "ASM task did not cancel"
         }
 
-        # setslot back to #0
+        # set slot 0 back to #0
         R 0 cluster setslot 0 node [R 0 cluster myid]
+        R 1 cluster setslot 0 node [R 0 cluster myid]
+        R 2 cluster setslot 0 node [R 0 cluster myid]
     }
 }

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -578,7 +578,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
 
         # flushall, flushdb, sflush
         foreach flushcmd {flushall flushdb sflush} {
-            # write some keys on R 0
+            # write some keys on R 1
             set slot0_key "06S"
             set slot1_key "Qi"
             R 1 set $slot0_key "a"
@@ -612,7 +612,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
 
         # Since sflush is executed on the source, the task is only canceled on the source.
         # The destination node will retry the import task, and eventually the slot 0-100
-        # migration will succeed.
+        # migration to #0 will succeed.
         R 1 config set rdb-key-save-delay 0
         wait_for_condition 1000 50 {
             [string match {*done*} [migration_status 0 $task_id state]] &&
@@ -620,5 +620,53 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         } else {
             fail "ASM task did not finish"
         }
+    }
+
+    test "CLUSTER SETSLOT command when there is a slot migration task" {
+        R 0 config set rdb-key-save-delay 1000000
+        # write some keys on R 0
+        set slot0_key "06S"
+        set slot1_key "Qi"
+        R 0 set $slot0_key "a"
+        R 0 set $slot1_key "b"
+
+        # start slot migration from 0 to 1
+        set task_id [R 1 CLUSTER MIGRATION IMPORT 0 100]
+        wait_for_condition 1000 20 {
+            [string match {*send-bulk-and-stream*} [migration_status 0 $task_id state]]
+        } else {
+            fail "ASM task did not start"
+        }
+
+        # Cluster SETSLOT command is not allowed when there is a slot migration task
+        # on the slot. #0 and #1 are having migration task now.
+        foreach instance {0 1} {     
+            set node_id [R $instance cluster myid]
+
+            catch {R $instance cluster setslot 0 migrating $node_id} err
+            assert_match {*in an active atomic slot migration*} $err
+
+            catch {R $instance cluster setslot 0 importing $node_id} err
+            assert_match {*in an active atomic slot migration*} $err
+
+            catch {R $instance cluster setslot 0 stable} err
+            assert_match {*in an active atomic slot migration*} $err
+
+            catch {R $instance cluster setslot 0 node $node_id} err
+            assert_match {*in an active atomic slot migration*} $err
+        }
+
+        # CLUSTER SETSLOT on other node will cancel the migration task
+        R 2 CLUSTER BUMPEPOCH
+        R 2 cluster setslot 0 node [R 2 cluster myid]
+        wait_for_condition 1000 50 {
+            [string match {*canceled*} [migration_status 0 $task_id state]] &&
+            [string match {*canceled*} [migration_status 1 $task_id state]]
+        } else {
+            fail "ASM task did not cancel"
+        }
+
+        # setslot back to #0
+        R 0 cluster setslot 0 node [R 0 cluster myid]
     }
 }

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -553,7 +553,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         R 0 config set rdb-key-save-delay 1000000
 
         # flushall, flushdb, sflush
-        for {set i 0} {$i < 3} {incr i} {
+        foreach flushcmd {flushall flushdb sflush} {
             # write some keys on R 0
             set slot0_key "06S"
             set slot1_key "Qi"
@@ -562,21 +562,22 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
 
             # start slot migration
             set task_id [R 1 CLUSTER MIGRATION IMPORT 0 100]
-            wait_for_condition 2000 10 {
+            wait_for_condition 1000 50 {
                 [string match {*send-bulk-and-stream*} [migration_status 0 $task_id state]]
             } else {
                 fail "ASM task did not start"
             }
 
-            if {$i == 0} {
+            if {$::verbose} { puts "flush command: $flushcmd"}
+            if {$flushcmd == "flushall"} {
                 R 1 flushall
-            } elseif {$i == 1} {
+            } elseif {$flushcmd == "flushdb"} {
                 R 1 flushdb
-            } else {
+            } elseif {$flushcmd == "sflush"} {
                 R 0 sflush 10 110
             }
 
-            # flush* will cancel the task
+            # flush-like will cancel the task
             wait_for_condition 1000 50 {
                 [string match {*canceled*} [migration_status 0 $task_id state]] ||
                 [string match {*canceled*} [migration_status 1 $task_id state]]

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -496,4 +496,102 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         for {set j 0} {$j < 100} {incr j} { R 1 ping } ;# trigger eviction
         assert_equal {} [scan [regexp -inline {expires\=([\d]*)} [R 1 info keyspace]] expires=%d]
     }
+
+    test "Failover will cancel slot migration tasks" {
+        set slot0_key "06S"
+        set slot1_key "Qi"
+        R 1 set $slot0_key "a"
+        R 1 set $slot1_key "b"
+        # we set a delay to failover
+        R 1 config set rdb-key-save-delay 1000000
+
+        set task_id [R 0 CLUSTER MIGRATION IMPORT 0 100]
+        wait_for_condition 2000 10 {
+            [string match {*send-bulk-and-stream*} [migration_status 1 $task_id state]]
+        } else {
+            fail "ASM task did not start"
+        }
+
+        # FAILOVER to instance #3
+        R 3 cluster failover force
+        wait_for_condition 1000 50 {
+            [getInfoProperty [R 3 info] role] eq {master}
+        } else {
+            fail "Instance #3 is not a master after some time"
+        }
+
+        # If a failover happens, the old master will cancel ASM task,
+        # and ASM task on another side of slot migration will be failed
+        wait_for_condition 1000 50 {
+            [string match {*canceled*} [migration_status 0 $task_id state]] &&
+            [string match {*failed*} [migration_status 1 $task_id state]]
+        } else {
+            fail "ASM task did not cancel"
+        }
+
+        # We can restart ASM tasks on new master
+        R 1 config set rdb-key-save-delay 0
+        set task_id [R 3 CLUSTER MIGRATION IMPORT 0 100]
+        wait_for_condition 1000 50 {
+            [string match {*done*} [migration_status 3 $task_id state]] &&
+            [string match {*done*} [migration_status 1 $task_id state]]
+        } else {
+            fail "ASM task did not finish"
+        }
+
+        # FAILOVER back to instance #2
+        R 0 cluster failover force
+        wait_for_condition 1000 50 {
+            [getInfoProperty [R 0 info] role] eq {master}
+        } else {
+            fail "Instance #0 is not a master after some time"
+        }
+    }
+
+    test "Flush-like command can cancel slot migration task" {
+        # we set a delay to cancel
+        R 0 config set rdb-key-save-delay 1000000
+
+        # flushall, flushdb, sflush
+        for {set i 0} {$i < 3} {incr i} {
+            # write some keys on R 0
+            set slot0_key "06S"
+            set slot1_key "Qi"
+            R 0 set $slot0_key "a"
+            R 0 set $slot1_key "b"
+
+            # start slot migration
+            set task_id [R 1 CLUSTER MIGRATION IMPORT 0 100]
+            wait_for_condition 2000 10 {
+                [string match {*send-bulk-and-stream*} [migration_status 0 $task_id state]]
+            } else {
+                fail "ASM task did not start"
+            }
+
+            if {$i == 0} {
+                R 1 flushall
+            } elseif {$i == 1} {
+                R 1 flushdb
+            } else {
+                R 0 sflush 10 110
+            }
+
+            # flush* will cancel the task
+            wait_for_condition 1000 50 {
+                [string match {*canceled*} [migration_status 0 $task_id state]] ||
+                [string match {*canceled*} [migration_status 1 $task_id state]]
+            } else {
+                fail "ASM task did not cancel"
+            }
+        }
+
+        # 0-100 migration will be successful
+        R 0 config set rdb-key-save-delay 0
+        wait_for_condition 1000 50 {
+            [string match {*done*} [migration_status 0 $task_id state]] &&
+            [string match {*done*} [migration_status 1 $task_id state]]
+        } else {
+            fail "ASM task did not finish"
+        }
+    }
 }


### PR DESCRIPTION
- flush-like command will cancel slot migration task
- switching to replica from master  will cancel slot migration task
- resolve the source node when starting importing tasks
- hide rdb/main channel client in `info replication`
- in `client list`, migrating client is marked as `m`, importing client is marked as `i`
-  show `asm_migrating_buffer` and `asm_importing_buffer` in `info memory`
- reject cluster setslot if there is an active slot migration, and cancel tasks if slot topology is changed