### PR TITLE
Some improvements and utility functions

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1636,6 +1636,10 @@ unsigned int clusterDelKeysInSlotRangeArray(slotRangeArray *sra, int flags) {
     return j;
 }
 
+int clusterIsMySlot(int slot) {
+    return getMyClusterNode() == getNodeBySlot(slot);
+}
+
 void replySlotsFlushAndFree(client *c, slotRangeArray *sra) {
     addReplyArrayLen(c, sra->num_ranges);
     for (int i = 0 ; i < sra->num_ranges ; i++) {
@@ -1713,6 +1717,83 @@ sds slotRangeArrayToString(slotRangeArray *sra) {
     s[sdslen(s)] = '\0';
 
     return s;
+}
+
+static int compareSlotRange(const void *a, const void *b) {
+    const slotRange *sa = a;
+    const slotRange *sb = b;
+    if (sa->start < sb->start) return -1;
+    if (sa->start > sb->start) return 1;
+    return 0;
+}
+
+/* Compare two slot range arrays, return 1 if equal, 0 otherwise */
+int slotRangeArrayIsEqual(slotRangeArray *sra1, slotRangeArray *sra2) {
+    if (sra1->num_ranges != sra2->num_ranges) return 0;
+
+    /* Sort slot ranges first */
+    qsort(sra1->ranges, sra1->num_ranges, sizeof(slotRange), compareSlotRange);
+    qsort(sra2->ranges, sra2->num_ranges, sizeof(slotRange), compareSlotRange);
+
+    for (int i = 0; i < sra1->num_ranges; i++) {
+        if (sra1->ranges[i].start != sra2->ranges[i].start ||
+            sra1->ranges[i].end != sra2->ranges[i].end) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+/* Add a slot to the slot range array.
+ * Usage:
+ *     slotRangeArray *sra = NULL
+ *     sra = slotRangeArrayBuild(sra, 1000);
+ *     sra = slotRangeArrayBuild(sra, 1001);
+ *     sra = slotRangeArrayBuild(sra, 1003);
+ *     sra = slotRangeArrayBuild(sra, 1004);
+ *     sra = slotRangeArrayBuild(sra, 1005);
+ *
+ *     Result: 1000-1001, 1003-1005
+ *     Note: `slot` must be greater than the previous slot.
+ * */
+slotRangeArray *slotRangeArrayBuild(slotRangeArray *sra, int slot) {
+    if (sra == NULL) {
+        sra = slotRangeArrayCreate(4);
+        sra->ranges[0].start = slot;
+        sra->ranges[0].end = slot;
+        sra->num_ranges = 1;
+        return sra;
+    }
+
+    serverAssert(sra->num_ranges >= 0 && sra->num_ranges <= CLUSTER_SLOTS);
+    serverAssert(slot > sra->ranges[sra->num_ranges - 1].end);
+
+    /* Check if we can extend the last range */
+    slotRange *last = &sra->ranges[sra->num_ranges - 1];
+    if (slot == last->end + 1) {
+        last->end = slot;
+        return sra;
+    }
+
+    /* Calculate current capacity and reallocate if needed */
+    int cap = (int) ((zmalloc_size(sra) - sizeof(slotRangeArray)) / sizeof(slotRange));
+    if (sra->num_ranges >= cap)
+        sra = zrealloc(sra, sizeof(slotRangeArray) + sizeof(slotRange) * cap * 2);
+
+    /* Add new single-slot range */
+    sra->ranges[sra->num_ranges].start = slot;
+    sra->ranges[sra->num_ranges].end = slot;
+    sra->num_ranges++;
+
+    return sra;
+}
+
+/* Returns 1 if the slot range array contains the given slot, 0 otherwise. */
+int slotRangeArrayContains(slotRangeArray *sra, unsigned int slot) {
+    for (int i = 0; i < sra->num_ranges; i++)
+        if (sra->ranges[i].start <= slot && sra->ranges[i].end >= slot)
+            return 1;
+    return 0;
 }
 
 /* Free the slot range array. */
@@ -1797,42 +1878,19 @@ void sflushCommand(client *c) {
      * a new slotRangeArray. It is allocated on heap since there is a chance
      * that FLUSH SYNC will be running as blocking ASYNC and only later reply
      * with slot ranges */
-    int in_slot_range = 0;
-    int capacity = 32; /* Initial capacity */
-
-    slotRangeArray *myslots = zmalloc(sizeof(*myslots) + sizeof(slotRange) * capacity);
-    myslots->num_ranges = 0;
-
+    slotRangeArray *myslots = NULL;
     for (int i = 0; i < slot_ranges->num_ranges; i++) {
         slotRange *sr = &slot_ranges->ranges[i];
-        for (int slot = sr->start; slot <= sr->end; slot++) {
-            if (myslots->num_ranges >= capacity) {
-                capacity *= 2;
-                myslots = zrealloc(myslots, sizeof(*myslots) + sizeof(slotRange) * capacity);
-            }
-            /* Check if this slot belongs to this node */
-            int myslot = (getNodeBySlot(slot) == getMyClusterNode());
-
-            /* Start range on first owned slot, end range on first unowned slot */
-            if (myslot && !in_slot_range) {
-                in_slot_range = 1;
-                myslots->ranges[myslots->num_ranges].start = slot;
-            } else if (!myslot && in_slot_range) {
-                in_slot_range = 0;
-                myslots->ranges[myslots->num_ranges++].end = slot - 1;
-            }
-        }
-        if (in_slot_range) {
-            /* End the current slot range if this is the last range or if
-             * there's a gap before the next range starts. */
-            int last_range = (i == slot_ranges->num_ranges - 1);
-            if (last_range || slot_ranges->ranges[i + 1].start != sr->end + 1) {
-                myslots->ranges[myslots->num_ranges++].end = sr->end;
-                in_slot_range = 0;
-            }
-        }
+        for (int slot = sr->start; slot <= sr->end; slot++)
+            if (clusterIsMySlot(slot))
+                myslots = slotRangeArrayBuild(myslots, slot);
     }
     zfree(slot_ranges);
+
+    if (myslots == NULL) {
+        addReply(c, shared.emptyarray);
+        return;
+    }
 
     /* Flush selected slots. If not flush as blocking async, then reply immediately */
     if (flushCommandCommon(c, FLUSH_TYPE_SLOTS, flags, myslots) == 0)

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1647,7 +1647,7 @@ void replySlotsFlushAndFree(client *c, slotRangeArray *sra) {
         addReplyLongLong(c, sra->ranges[i].start);
         addReplyLongLong(c, sra->ranges[i].end);
     }
-    zfree(sra);
+    slotRangeArrayFree(sra);
 }
 
 /* Checks that slot ranges are well-formed and non-overlapping. */

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1747,16 +1747,16 @@ int slotRangeArrayIsEqual(slotRangeArray *sra1, slotRangeArray *sra2) {
 /* Add a slot to the slot range array.
  * Usage:
  *     slotRangeArray *sra = NULL
- *     sra = slotRangeArrayBuild(sra, 1000);
- *     sra = slotRangeArrayBuild(sra, 1001);
- *     sra = slotRangeArrayBuild(sra, 1003);
- *     sra = slotRangeArrayBuild(sra, 1004);
- *     sra = slotRangeArrayBuild(sra, 1005);
+ *     sra = slotRangeArrayAppend(sra, 1000);
+ *     sra = slotRangeArrayAppend(sra, 1001);
+ *     sra = slotRangeArrayAppend(sra, 1003);
+ *     sra = slotRangeArrayAppend(sra, 1004);
+ *     sra = slotRangeArrayAppend(sra, 1005);
  *
  *     Result: 1000-1001, 1003-1005
  *     Note: `slot` must be greater than the previous slot.
  * */
-slotRangeArray *slotRangeArrayBuild(slotRangeArray *sra, int slot) {
+slotRangeArray *slotRangeArrayAppend(slotRangeArray *sra, int slot) {
     if (sra == NULL) {
         sra = slotRangeArrayCreate(4);
         sra->ranges[0].start = slot;
@@ -1883,7 +1883,7 @@ void sflushCommand(client *c) {
         slotRange *sr = &slot_ranges->ranges[i];
         for (int slot = sr->start; slot <= sr->end; slot++)
             if (clusterIsMySlot(slot))
-                myslots = slotRangeArrayBuild(myslots, slot);
+                myslots = slotRangeArrayAppend(myslots, slot);
     }
     zfree(slot_ranges);
 

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -157,7 +157,7 @@ slotRangeArray *slotRangeArrayDup(slotRangeArray *sra);
 void slotRangeArraySet(slotRangeArray *sra, int idx, int start, int end);
 sds slotRangeArrayToString(slotRangeArray *sra);
 int slotRangeArrayIsEqual(slotRangeArray *sra1, slotRangeArray *sra2);
-slotRangeArray *slotRangeArrayBuild(slotRangeArray *sra, int slot);
+slotRangeArray *slotRangeArrayAppend(slotRangeArray *sra, int slot);
 int slotRangeArrayContains(slotRangeArray *sra, unsigned int slot);
 void slotRangeArrayFree(slotRangeArray *sra);
 int validateSlotRanges(slotRangeArray *sra, sds *err);

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -131,6 +131,7 @@ const char *clusterNodePreferredEndpoint(clusterNode *n);
 long long clusterNodeReplOffset(clusterNode *node);
 clusterNode *clusterLookupNode(const char *name, int length);
 const char *clusterGetSecret(size_t *len);
+int clusterIsMySlot(int slot);
 
 /* functions with shared implementations */
 clusterNode *getNodeByQuery(client *c, struct redisCommand *cmd, robj **argv, int argc, int *hashslot, uint64_t cmd_flags, int *error_code);
@@ -155,6 +156,9 @@ slotRangeArray *slotRangeArrayCreate(int num_ranges);
 slotRangeArray *slotRangeArrayDup(slotRangeArray *sra);
 void slotRangeArraySet(slotRangeArray *sra, int idx, int start, int end);
 sds slotRangeArrayToString(slotRangeArray *sra);
+int slotRangeArrayIsEqual(slotRangeArray *sra1, slotRangeArray *sra2);
+slotRangeArray *slotRangeArrayBuild(slotRangeArray *sra, int slot);
+int slotRangeArrayContains(slotRangeArray *sra, unsigned int slot);
 void slotRangeArrayFree(slotRangeArray *sra);
 int validateSlotRanges(slotRangeArray *sra, sds *err);
 slotRangeArray *parseSlotRangesOrReply(client *c, int argc, int pos);

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -18,6 +18,9 @@
 #define ASM_MAX_DONE_TASKS 32 /* Maximum number of completed tasks to keep in memory. */
 #define ASM_PAUSE_WRITE_MAX_GAP_BYTES (1 * 1024 * 1024) /* 1MB, TODO: a new config */
 
+#define ASM_DEBUG_TRIM_DEFAULT 0
+#define ASM_DEBUG_TRIM_NONE 1
+
 typedef struct asmTask {
     sds id;                             /* Task ID */
     int operation;                      /* Either ASM_IMPORT or ASM_MIGRATE */
@@ -52,6 +55,7 @@ struct asmManager {
     /* Fail point injection for debugging */
     int debug_failed_channel;     /* Channel where the task failed */
     int debug_failed_state;       /* State where the task failed */
+    int debug_trim_method;        /* Method to trim the buffer */
 };
 
 enum asmState {
@@ -118,6 +122,7 @@ void clusterAsmInit(void) {
     asmManager->total_done_tasks = 0;
     asmManager->debug_failed_channel = 0;
     asmManager->debug_failed_state = 0;
+    asmManager->debug_trim_method = ASM_DEBUG_TRIM_DEFAULT;
 }
 
 char *asmTaskStateToString(int state) {
@@ -206,6 +211,31 @@ const char *asmChannelToString(int channel) {
     }
 }
 
+int asmDebugSetTrimMethod(const char *method) {
+    if (!asmManager) {
+        serverLog(LL_WARNING, "ASM manager is not initialized");
+        return C_ERR;
+    }
+
+    int prev = asmManager->debug_trim_method;
+    if (!strcasecmp(method, "default")) asmManager->debug_trim_method = ASM_DEBUG_TRIM_DEFAULT;
+    else if (!strcasecmp(method, "none")) asmManager->debug_trim_method = ASM_DEBUG_TRIM_NONE;
+    else return C_ERR;
+
+    /* If we are switching from none to default, delete all the keys in the
+     * slots we don't own */
+    if (prev == ASM_DEBUG_TRIM_NONE && asmManager->debug_trim_method != ASM_DEBUG_TRIM_NONE) {
+        for (int i = 0; i < CLUSTER_SLOTS; i++)
+            if (!clusterIsMySlot(i))
+                clusterDelKeysInSlot(i, CLUSTER_DELKEYS_ASYNC);
+    }
+    return C_OK;
+}
+
+int asmCanTrimSlots(void) {
+    return !asmManager || asmManager->debug_trim_method == ASM_DEBUG_TRIM_DEFAULT;
+}
+
 int asmDebugIsFailPointActive(int channel, int state) {
     if (!asmManager) return 0; /* ASM manager not initialized */
     if (asmManager->debug_failed_channel == channel && asmManager->debug_failed_state == state) {
@@ -214,6 +244,30 @@ int asmDebugIsFailPointActive(int channel, int state) {
         return 1;
     }
     return 0;
+}
+
+sds asmGenInfoString(sds info) {
+    int active_tasks = 0;
+
+    listIter li;
+    listNode *ln;
+    listRewind(asmManager->tasks, &li);
+    while ((ln = listNext(&li)) != NULL) {
+        asmTask *task = listNodeValue(ln);
+        if (task->operation == ASM_IMPORT ||
+            (task->operation == ASM_MIGRATE && task->state != ASM_FAILED))
+        {
+            active_tasks++;
+        }
+    }
+
+    return sdscatprintf(info,
+                        "cluster_slot_migration_task_count:%d\r\n"
+                        "cluster_slot_migration_total_done_tasks:%lld\r\n"
+                        "cluster_slot_migration_sync_buffer_peak:%zu\r\n",
+                        active_tasks,
+                        asmManager->total_done_tasks,
+                        asmGetPeakSyncBufferSize());
 }
 
 void asmTaskReset(asmTask *task) {
@@ -319,42 +373,22 @@ size_t asmGetMigratingBufferSize(void) {
     return 0;
 }
 
-static int compareSlotRange(const void *a, const void *b) {
-    const slotRange *sa = a;
-    const slotRange *sb = b;
-    if (sa->start < sb->start) return -1;
-    if (sa->start > sb->start) return 1;
-    return 0;
-}
-
-/* Compare two slot range arrays, return 1 if equal, 0 otherwise */
-static int slotRangeArrayIsEqual(slotRangeArray *sra1, slotRangeArray *sra2) {
-    if (sra1->num_ranges != sra2->num_ranges) return 0;
-
-    /* Sort slot ranges first */
-    qsort(sra1->ranges, sra1->num_ranges, sizeof(slotRange), compareSlotRange);
-    qsort(sra2->ranges, sra2->num_ranges, sizeof(slotRange), compareSlotRange);
-
-    for (int i = 0; i < sra1->num_ranges; i++) {
-        if (sra1->ranges[i].start != sra2->ranges[i].start ||
-            sra1->ranges[i].end != sra2->ranges[i].end) {
-            return 0;
-        }
-    }
-    return 1;
-}
-
 /* Returns the ASM task with the given ID, or NULL if no such task exists. */
-asmTask *lookupAsmTaskById(const char *id) {
+static asmTask *lookupAsmTaskAt(list *tasks, const char *id) {
     listIter li;
     listNode *ln;
 
-    listRewind(asmManager->tasks, &li);
+    listRewind(tasks, &li);
     while ((ln = listNext(&li)) != NULL) {
         asmTask *task = listNodeValue(ln);
         if (!strcmp(task->id, id)) return task;
     }
     return NULL;
+}
+
+/* Returns the ASM task with the given ID, or NULL if no such task exists. */
+asmTask *lookupAsmTaskById(const char *id) {
+    return lookupAsmTaskAt(asmManager->tasks, id);
 }
 
 /* Returns the ASM task that is identical to the given slot range array, or NULL
@@ -694,21 +728,43 @@ static void replyTaskStatus(client *c, asmTask *task) {
     addReplyBulkLongLong(c, p);
 }
 
-/* CLUSTER MIGRATION STATUS
+/* CLUSTER MIGRATION STATUS [ID <task-id>]
  *  - Reply: Array of atomic slot migration tasks */
 static void clusterMigrationCommandStatus(client *c) {
     listIter li;
     listNode *ln;
 
-    addReplyArrayLen(c, listLength(asmManager->tasks) + listLength(asmManager->done_tasks));
+    if (c->argc != 3 && c->argc != 5) {
+        addReplyErrorArity(c);
+        return;
+    }
 
-    listRewind(asmManager->tasks, &li);
-    while ((ln = listNext(&li)) != NULL)
-        replyTaskStatus(c, listNodeValue(ln));
+    if (c->argc == 5) {
+        if (strcasecmp(c->argv[3]->ptr, "id") != 0) {
+            addReplyError(c, "unknown argument");
+            return;
+        }
+        sds id = c->argv[4]->ptr;
+        asmTask *task = lookupAsmTaskAt(asmManager->tasks, id);
+        if (!task) task = lookupAsmTaskAt(asmManager->done_tasks, id);
+        if (!task) {
+            addReplyArrayLen(c, 0);
+            return;
+        }
 
-    listRewind(asmManager->done_tasks, &li);
-    while ((ln = listNext(&li)) != NULL)
-        replyTaskStatus(c, listNodeValue(ln));
+        addReplyArrayLen(c, 1);
+        replyTaskStatus(c, task);
+    } else {
+        addReplyArrayLen(c, listLength(asmManager->tasks) +
+                            listLength(asmManager->done_tasks));
+        listRewind(asmManager->tasks, &li);
+        while ((ln = listNext(&li)) != NULL)
+            replyTaskStatus(c, listNodeValue(ln));
+
+        listRewind(asmManager->done_tasks, &li);
+        while ((ln = listNext(&li)) != NULL)
+            replyTaskStatus(c, listNodeValue(ln));
+    }
 }
 
 /* CLUSTER MIGRATION

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -261,7 +261,7 @@ sds asmCatInfoString(sds info) {
         }
     }
 
-    return sdscatprintf(info,
+    return sdscatprintf(info ? info : sdsempty(),
                         "cluster_slot_migration_task_count:%d\r\n"
                         "cluster_slot_migration_total_done_tasks:%lld\r\n"
                         "cluster_slot_migration_sync_buffer_peak:%zu\r\n",

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -246,7 +246,7 @@ int asmDebugIsFailPointActive(int channel, int state) {
     return 0;
 }
 
-sds asmGenInfoString(sds info) {
+sds asmCatInfoString(sds info) {
     int active_tasks = 0;
 
     listIter li;

--- a/src/cluster_asm.h
+++ b/src/cluster_asm.h
@@ -31,6 +31,9 @@ size_t asmGetMigratingBufferSize(void);
 int clusterAsmCancel(const char *task_id, const char *reason);
 int clusterAsmCancelBySlotRangeArray(struct slotRangeArray *slot_ranges, const char *reason);
 int isSlotInAsmTask(int slot);
+sds asmGenInfoString(sds info);
+int asmDebugSetTrimMethod(const char *method);
+int asmCanTrimSlots(void);
 
 void clusterMigrationCommand(client *c);
 void clusterSyncSlotsCommand(client *c);

--- a/src/cluster_asm.h
+++ b/src/cluster_asm.h
@@ -31,7 +31,7 @@ size_t asmGetMigratingBufferSize(void);
 int clusterAsmCancel(const char *task_id, const char *reason);
 int clusterAsmCancelBySlotRangeArray(struct slotRangeArray *slot_ranges, const char *reason);
 int isSlotInAsmTask(int slot);
-sds asmGenInfoString(sds info);
+sds asmCatInfoString(sds info);
 int asmDebugSetTrimMethod(const char *method);
 int asmCanTrimSlots(void);
 

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2389,7 +2389,7 @@ void clusterUpdateSlotsConfigWith(clusterNode *sender, uint64_t senderConfigEpoc
                  * detect that the slot was moved from us to the sender, and
                  * send ASM_REQUEST_CONFIG_UPDATED request to ASM later. */
                 if (server.cluster->slots[j] == myself && sender != myself)
-                    sra = slotRangeArrayBuild(sra, j);
+                    sra = slotRangeArrayAppend(sra, j);
 
                 /* Was this slot mine, and still contains keys? Mark it as
                  * a dirty slot. */

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2431,7 +2431,7 @@ void clusterUpdateSlotsConfigWith(clusterNode *sender, uint64_t senderConfigEpoc
             sdsfree(err);
         }
     }
-    zfree(sra);
+    slotRangeArrayFree(sra);
 
     /* After updating the slots configuration, don't do any actual change
      * in the state of the server if a module disabled Redis Cluster

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2360,6 +2360,7 @@ void clusterUpdateSlotsConfigWith(clusterNode *sender, uint64_t senderConfigEpoc
         return;
     }
 
+    slotRangeArray *sra = NULL;
     for (j = 0; j < CLUSTER_SLOTS; j++) {
         if (bitmapTestBit(slots,j)) {
             sender_slots++;
@@ -2387,9 +2388,8 @@ void clusterUpdateSlotsConfigWith(clusterNode *sender, uint64_t senderConfigEpoc
                  * will broadcast a PONG message to all the nodes. We need to
                  * detect that the slot was moved from us to the sender, and
                  * send ASM_REQUEST_CONFIG_UPDATED request to ASM later. */
-                if (server.cluster->slots[j] == myself && sender != myself) {
-                    asm_detect_updated_slots[j] = 1;
-                }
+                if (server.cluster->slots[j] == myself && sender != myself)
+                    sra = slotRangeArrayBuild(sra, j);
 
                 /* Was this slot mine, and still contains keys? Mark it as
                  * a dirty slot. */
@@ -2423,30 +2423,8 @@ void clusterUpdateSlotsConfigWith(clusterNode *sender, uint64_t senderConfigEpoc
         }
     }
 
-    /* Transform the bitmap to a list of slot ranges, and send a request to ASM. */
-    slotRangeArray *sra = zmalloc(sizeof(*sra) + sizeof(slotRange) * CLUSTER_SLOTS);
-    sra->num_ranges = 0;
-    int start = -1;
-    for (int i = 0; i < CLUSTER_SLOTS; i++) {
-        if (asm_detect_updated_slots[i]) {
-            if (start == -1) {
-                start = i;
-            }
-        } else {
-            if (start != -1) {
-                sra->ranges[sra->num_ranges].start = start;
-                sra->ranges[sra->num_ranges].end = i - 1;
-                sra->num_ranges++;
-                start = -1;
-            }
-        }
-    }
-    if (start != -1) {
-        sra->ranges[sra->num_ranges].start = start;
-        sra->ranges[sra->num_ranges].end = CLUSTER_SLOTS - 1;
-        sra->num_ranges++;
-    }
-    if (sra->num_ranges > 0 && server.masterhost == NULL) {
+    /* Notify ASM about the config update */
+    if (sra && sra->num_ranges > 0 && server.masterhost == NULL) {
         sds err = NULL;
         if (asmNotifyConfigUpdated(NULL, sra, &err) != C_OK) {
             serverLog(LL_WARNING, "ASM config update failed: %s", err);
@@ -2495,7 +2473,7 @@ void clusterUpdateSlotsConfigWith(clusterNode *sender, uint64_t senderConfigEpoc
         clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG|
                              CLUSTER_TODO_UPDATE_STATE|
                              CLUSTER_TODO_FSYNC_CONFIG);
-    } else if (dirty_slots_count) {
+    } else if (dirty_slots_count && asmCanTrimSlots()) {
         /* If we are here, we received an update message which removed
          * ownership for certain slots we still have keys about, but still
          * we are serving some slots, so this master node was not demoted to
@@ -5786,7 +5764,6 @@ sds genClusterInfoString(void) {
         "cluster_size:%d\r\n"
         "cluster_current_epoch:%llu\r\n"
         "cluster_my_epoch:%llu\r\n"
-        "cluster_slot_migration_sync_buffer_peak:%zu\r\n"
         , statestr[server.cluster->state],
         slots_assigned,
         slots_ok,
@@ -5795,8 +5772,7 @@ sds genClusterInfoString(void) {
         dictSize(server.cluster->nodes),
         server.cluster->size,
         (unsigned long long) server.cluster->currentEpoch,
-        (unsigned long long) myepoch,
-        asmGetPeakSyncBufferSize()
+        (unsigned long long) myepoch
     );
 
     /* Show stats about messages sent and received. */
@@ -5828,6 +5804,8 @@ sds genClusterInfoString(void) {
     info = sdscatprintf(info,
         "total_cluster_links_buffer_limit_exceeded:%llu\r\n",
         server.cluster->stat_cluster_links_buffer_limit_exceeded);
+
+    info = asmGenInfoString(info);
 
     return info;
 }

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -5805,7 +5805,7 @@ sds genClusterInfoString(void) {
         "total_cluster_links_buffer_limit_exceeded:%llu\r\n",
         server.cluster->stat_cluster_links_buffer_limit_exceeded);
 
-    info = asmGenInfoString(info);
+    info = asmCatInfoString(info);
 
     return info;
 }

--- a/src/cluster_plugin.c
+++ b/src/cluster_plugin.c
@@ -104,7 +104,7 @@ void clusterPromoteSelfToMaster(void) {
 
 sds genClusterInfoString(void) {
     sds info = clusterPlugin->genClusterInfoString();
-    info = asmGenInfoString(info);
+    info = asmCatInfoString(info);
     return info;
 }
 

--- a/src/cluster_plugin.c
+++ b/src/cluster_plugin.c
@@ -9,6 +9,7 @@
 
 #include "server.h"
 #include "cluster.h"
+#include "cluster_asm.h"
 #include "cluster_plugin.h"
 
 ClusterPlugin *clusterPlugin = NULL;
@@ -102,7 +103,9 @@ void clusterPromoteSelfToMaster(void) {
 }
 
 sds genClusterInfoString(void) {
-    return clusterPlugin->genClusterInfoString();
+    sds info = clusterPlugin->genClusterInfoString();
+    info = asmGenInfoString(info);
+    return info;
 }
 
 int getClusterSize(void) {
@@ -164,7 +167,7 @@ void clusterInitLast(void) {
 }
 
 void clusterBeforeSleep(void) {
-    // TODO: call asmBeforeSleep();
+    asmBeforeSleep();
 }
 
 int verifyClusterConfigWithData(void) {

--- a/src/db.c
+++ b/src/db.c
@@ -1034,7 +1034,7 @@ void flushallSyncBgDone(uint64_t client_id, void *userdata) {
 
     /* Verify that client still exists and being blocked. */
     if (!(c && c->flags & CLIENT_BLOCKED)) {
-        zfree(sra);
+        slotRangeArrayFree(sra);
         return;
     }
 

--- a/src/debug.c
+++ b/src/debug.c
@@ -501,6 +501,8 @@ void debugCommand(client *c) {
 "    Promote the current connection to an internal connection.",
 "ASM-FAILPOINT <channel> <state>",
 "    Set a fail point for the specified channel and state for cluster atomic slot migration.",
+"ASM-TRIM-METHOD <default|none> ",
+"    Disable trimming for cluster atomic slot migration.",
 NULL
         };
         addExtendedReplyHelp(c, help, clusterDebugCommandExtendedHelp());
@@ -1103,6 +1105,12 @@ NULL
     } else if(!strcasecmp(c->argv[1]->ptr,"asm-failpoint") && c->argc == 4) {
         if (asmDebugSetFailPoint(c->argv[2]->ptr, c->argv[3]->ptr) != C_OK) {
             addReplyError(c, "Failed to set ASM fail point");
+        } else {
+            addReply(c, shared.ok);
+        }
+    } else if(!strcasecmp(c->argv[1]->ptr,"asm-trim-method") && c->argc == 3) {
+        if (asmDebugSetTrimMethod(c->argv[2]->ptr) != C_OK) {
+            addReplyError(c, "Failed to set ASM trim method");
         } else {
             addReply(c, shared.ok);
         }

--- a/tests/support/cluster_util.tcl
+++ b/tests/support/cluster_util.tcl
@@ -105,6 +105,8 @@ proc cluster_setup {masters node_count slot_allocator code} {
 # Start a cluster with the given number of masters and replicas. Replicas
 # will be allocated to masters by round robin.
 proc start_cluster {masters replicas options code {slot_allocator continuous_slot_allocation}} {
+    set ::cluster_master_nodes $masters
+    set ::cluster_replica_nodes $replicas
     set node_count [expr $masters + $replicas]
 
     # Set the final code to be the tests + cluster setup

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -67,38 +67,31 @@ proc populate_slot {num args} {
         }
     }
 
-    # Try R first (cluster), fallback to r (single instance)
-    if {[catch {R $idx ping}]} {
-        set redis_cmd "r"
-    } else {
-        set redis_cmd "R"
-    }
-
-    $redis_cmd $idx deferred 1
+    R $idx deferred 1
     if {$num > 16} {set pipeline 16} else {set pipeline $num}
     set val [string repeat A $size]
     for {set j 0} {$j < $pipeline} {incr j} {
         if {$expires > 0} {
-            $redis_cmd $idx set $prefix$j $val ex $expires
+            R $idx set $prefix$j $val ex $expires
         } else {
-            $redis_cmd $idx set $prefix$j $val
+            R $idx set $prefix$j $val
         }
         if {$prints} {puts $j}
     }
     for {} {$j < $num} {incr j} {
         if {$expires > 0} {
-            $redis_cmd $idx set $prefix$j $val ex $expires
+            R $idx set $prefix$j $val ex $expires
         } else {
-            $redis_cmd $idx set $prefix$j $val
+            R $idx set $prefix$j $val
         }
-        $redis_cmd $idx read
+        R $idx read
         if {$prints} {puts $j}
     }
     for {set j 0} {$j < $pipeline} {incr j} {
-        $redis_cmd $idx read
+        R $idx read
         if {$prints} {puts $j}
     }
-    $redis_cmd $idx deferred 0
+    R $idx deferred 0
 }
 
 # Wait for all ASM tasks to complete in the cluster

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -1,29 +1,143 @@
-proc migration_status {node_id task_id field} {
-    set status [R $node_id CLUSTER MIGRATION STATUS]
+set ::slot_prefixes [dict create \
+    0 "{06S}" \
+    1 "{Qi}" \
+    2 "{5L5}" \
+    3 "{4Iu}" \
+    4 "{4gY}" \
+    5 "{460}" \
+    6 "{1Y7}" \
+    7 "{1LV}" \
+    101 "{1j2}" \
+    6000 "{4L7}" \
+    6001 "{4YV}" \
+    6002 "{0bx}" \
+    6003 "{AJ}" \
+    6004 "{of}" \
+]
 
-    # Iterate through each migration operation
-    foreach operation $status {
-        set task_id_found ""
-        set field_value ""
+# Helper functions
+proc get_port {node_id} {
+    if {$::tls} {
+        return [lindex [R $node_id config get tls-port] 1]
+    } else {
+        return [lindex [R $node_id config get port] 1]
+    }
+}
 
-        # Parse the key-value pairs in the operation
-        for {set i 0} {$i < [llength $operation]} {incr i 2} {
-            set key [lindex $operation $i]
-            set value [lindex $operation [expr $i + 1]]
+# return the prefix for the given slot
+proc slot_prefix {slot} {
+    return [dict get $::slot_prefixes $slot]
+}
 
-            if {$key eq "id"} {
-                set task_id_found $value
-            } elseif {$key eq $field} {
-                set field_value $value
-            }
-        }
-        # Check if this operation matches the requested task_id
-        if {$task_id_found eq $task_id} {
-            return $field_value
+# return a key for the given slot
+proc slot_key {slot {suffix ""}} {
+    return "[slot_prefix $slot]$suffix"
+}
+
+# Populate a slot with keys
+# TODO: Merge with populate()
+proc populate_slot {num args} {
+    # Default values
+    set prefix "key:"
+    set size 3
+    set idx 0
+    set prints false
+    set expires 0
+    set slot -1
+
+    # Parse named arguments
+    foreach {key value} $args {
+        switch -- $key {
+            -prefix { set prefix $value }
+            -size { set size $value }
+            -idx { set idx $value }
+            -prints { set prints $value }
+            -expires { set expires $value }
+            -slot { set slot $value }
+            default { error "Unknown option: $key" }
         }
     }
-    # Return empty string if slots_range not found or field not found
-    return ""
+
+    # If slot is specified, use slot prefix from table
+    if {$slot >= 0} {
+        if {[dict exists $::slot_prefixes $slot]} {
+            set prefix [dict get $::slot_prefixes $slot]
+        } else {
+            error "Slot $slot not supported in slot_prefixes table, add it manually"
+        }
+    }
+
+    # Try R first (cluster), fallback to r (single instance)
+    if {[catch {R $idx ping}]} {
+        set redis_cmd "r"
+    } else {
+        set redis_cmd "R"
+    }
+
+    $redis_cmd $idx deferred 1
+    if {$num > 16} {set pipeline 16} else {set pipeline $num}
+    set val [string repeat A $size]
+    for {set j 0} {$j < $pipeline} {incr j} {
+        if {$expires > 0} {
+            $redis_cmd $idx set $prefix$j $val ex $expires
+        } else {
+            $redis_cmd $idx set $prefix$j $val
+        }
+        if {$prints} {puts $j}
+    }
+    for {} {$j < $num} {incr j} {
+        if {$expires > 0} {
+            $redis_cmd $idx set $prefix$j $val ex $expires
+        } else {
+            $redis_cmd $idx set $prefix$j $val
+        }
+        $redis_cmd $idx read
+        if {$prints} {puts $j}
+    }
+    for {set j 0} {$j < $pipeline} {incr j} {
+        $redis_cmd $idx read
+        if {$prints} {puts $j}
+    }
+    $redis_cmd $idx deferred 0
+}
+
+# Wait for all ASM tasks to complete in the cluster
+proc wait_for_asm_done {} {
+    set total_instances [expr {$::cluster_master_nodes + $::cluster_replica_nodes}]
+
+    for {set i 0} {$i < $total_instances} {incr i} {
+        wait_for_condition 1000 10 {
+            [CI $i cluster_slot_migration_task_count] == 0
+        } else {
+            set migration_count [CI $i cluster_slot_migration_task_count]
+            fail "ASM tasks did not complete on instance $i: migration_tasks=$migration_count"
+        }
+    }
+}
+
+proc migration_status {node_id task_id field} {
+    set status [R $node_id CLUSTER MIGRATION STATUS ID $task_id]
+
+    # STATUS ID returns single task, so get first element
+    if {[llength $status] == 0} {
+        return ""
+    }
+
+    set task_status [lindex $status 0]
+    set field_value ""
+
+    # Parse the key-value pairs in the task
+    for {set i 0} {$i < [llength $task_status]} {incr i 2} {
+        set key [lindex $task_status $i]
+        set value [lindex $task_status [expr $i + 1]]
+
+        if {$key eq $field} {
+            set field_value $value
+            break
+        }
+    }
+
+    return $field_value
 }
 
 start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 30000}} {
@@ -106,6 +220,74 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         assert_equal "tag22273" [R 0 get tag22273]
         assert_equal "tag9283" [R 0 get tag9283]
         R 1 config set rdb-key-save-delay 0
+
+        # revert the migration
+        R 1 CLUSTER MIGRATION IMPORT 7000 8000
+        wait_for_asm_done
+    }
+
+    test "Simple slot migration with write load" {
+        # Perform slot migration while write traffic is active and verify data
+        # consistency. Trimming is disabled on source nodes to ensure no updates
+        # are lost during migration. Data integrity is verified using
+        # DEBUG DIGEST command.
+        # Steps:
+        # 1. Populate slot 0 on node-0 and slot 6000 on node-1
+        # 2. Start write traffic on both nodes
+        # 3. Migrate slot 0 from node-0 to node-1
+        # 4. Migrate slot 6000 from node-1 to node-0
+        # 5. Stop write traffic, verify db's are identical.
+
+        R 0 flushall
+        R 0 debug asm-trim-method none
+        populate_slot 10000 -idx 0 -slot 0
+
+        R 1 flushall
+        R 1 debug asm-trim-method none
+        populate_slot 10000 -idx 1 -slot 6000
+
+        # Start write traffic on node-0
+        # Throws -MOVED error once asm is completed, catch block will ignore it.
+        catch {
+            # Start the slot 0 write load on the R 0
+            set port [get_port 0]
+            set key [slot_key 0 mykey]
+            set load_handle0 [start_write_load "127.0.0.1" $port 100 $key]
+        }
+
+        # Start write traffic on node10
+        # Throws -MOVED error once asm is completed, catch block will ignore it.
+        catch {
+            # Start the slot 6000 write load on the R 1
+            set port [get_port 1]
+            set key [slot_key 6000 mykey]
+            set load_handle1 [start_write_load "127.0.0.1" $port 100 $key]
+        }
+
+        # Migrate keys
+        R 1 CLUSTER MIGRATION IMPORT 0 100
+        wait_for_asm_done
+        R 0 CLUSTER MIGRATION IMPORT 6000 6100
+        wait_for_asm_done
+
+        stop_write_load $load_handle0
+        stop_write_load $load_handle1
+
+        # verify data
+        assert_morethan [R 0 dbsize] 0
+        assert_equal [R 0 dbsize] [R 1 dbsize]
+        assert_equal [R 0 debug digest] [R 1 debug digest]
+
+        # cleanup
+        R 0 debug asm-trim-method default
+        R 0 flushall
+        R 1 debug asm-trim-method default
+        R 1 flushall
+
+        R 0 CLUSTER MIGRATION IMPORT 0 100
+        wait_for_asm_done
+        R 1 CLUSTER MIGRATION IMPORT 6000 6100
+        wait_for_asm_done
     }
 
     test "Simple slot migration" {
@@ -117,7 +299,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         R 0 set $slot101_key "c"
         # 3 keys cost 3s to save
         R 0 config set rdb-key-save-delay 1000000
-    
+
         # migrate slot 0-100 to R 1
         set task_id [R 1 CLUSTER MIGRATION IMPORT 0 100]
         # migration is start, and in accumulating buffer stage
@@ -173,9 +355,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
             }
 
             # Start the slot 0 write load on the R 1
-            if {$::tls} { set port [lindex [R 1 config get tls-port] 1]
-            } else { set port [lindex [R 1 config get port] 1] }
-            set load_handle [start_write_load "127.0.0.1" $port 500 "06S"]
+            set load_handle [start_write_load "127.0.0.1" [get_port 1] 500 "06S"]
 
             # clear old fail points and set the new fail point
             assert_equal {OK} [R 0 debug asm-failpoint "" ""]
@@ -257,9 +437,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         R 1 config set rdb-key-save-delay 1000000
 
         # Start the slot 0 write load on the R 1
-        if {$::tls} { set port [lindex [R 1 config get tls-port] 1]
-        } else { set port [lindex [R 1 config get port] 1] }
-        set load_handle [start_write_load "127.0.0.1" $port 100 $slot0_key]
+        set load_handle [start_write_load "127.0.0.1" [get_port 1] 100 $slot0_key]
 
         # Clear all fail points
         assert_equal {OK} [R 0 debug asm-failpoint "" ""]
@@ -317,9 +495,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         set loglines [count_log_lines 0]
 
         # Start the slot 0 write load on the R 0
-        if {$::tls} { set port [lindex [R 0 config get tls-port] 1]
-        } else { set port [lindex [R 0 config get port] 1] }
-        set load_handle [start_write_load "127.0.0.1" $port 1000 $slot0_key]
+        set load_handle [start_write_load "127.0.0.1" [get_port 0] 1000 $slot0_key]
 
         # After some time, the client output buffer limit should be reached
         wait_for_log_messages 0 {"*Client * closed * for overcoming of output buffer limits.*"} $loglines 1000 10

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -35,7 +35,7 @@ proc slot_key {slot {suffix ""}} {
 }
 
 # Populate a slot with keys
-# TODO: Merge with populate()
+# TODO: Consider merging with populate()
 proc populate_slot {num args} {
     # Default values
     set prefix "key:"
@@ -227,12 +227,12 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
     }
 
     test "Simple slot migration with write load" {
-        # Perform slot migration while write traffic is active and verify data
-        # consistency. Trimming is disabled on source nodes to ensure no updates
-        # are lost during migration. Data integrity is verified using
-        # DEBUG DIGEST command.
+        # Perform slot migration while traffic is on and verify data consistency.
+        # Trimming is disabled on source nodes so, we can compare the dbs after
+        # migration via DEBUG DIGEST to ensure no data loss during migration.
         # Steps:
-        # 1. Populate slot 0 on node-0 and slot 6000 on node-1
+        # 1. Disable trimming on both nodes
+        # 2. Populate slot 0 on node-0 and slot 6000 on node-1
         # 2. Start write traffic on both nodes
         # 3. Migrate slot 0 from node-0 to node-1
         # 4. Migrate slot 6000 from node-1 to node-0
@@ -255,7 +255,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
             set load_handle0 [start_write_load "127.0.0.1" $port 100 $key]
         }
 
-        # Start write traffic on node10
+        # Start write traffic on node-1
         # Throws -MOVED error once asm is completed, catch block will ignore it.
         catch {
             # Start the slot 6000 write load on the R 1


### PR DESCRIPTION
@ShooterIT I was accumulating some changes on my trim branch, it is getting bigger. So, I believe we can merge some of them separately:

Changes:
1. Added `[ID <task_id]` parameter to `CLUSTER MIGRATION STATUS`. If specified, only the given task is returned. This is just for convenience if task list is crowded. 
2. Moved some slotRangeArray functions together and added a few more for convenience. We better have their declaration in cluster.h so that plugin may use if needed. 
3. Added a debug parameter to disable trim. In a later PR, we can have more options to switch between active and background trim. 
4. Added `asmGenInfoString()` to be able to generate info string for both plugin and legacy implementations.
5. Added some helper functions to tests. 