### PR TITLE
Recalculating slot of argv can cause crash in feedDestination since argv may be written

### DIFF
--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -592,7 +592,7 @@ void asmFeedMigrationClient(robj **argv, int argc) {
         if (!sdsEncodedObject(argv[i])) {
             serverAssert(argv[i]->encoding == OBJ_ENCODING_INT);
             robj *old = argv[i];
-            argv[i] = createStringObjectFromLongLongWithSds((long long)old->ptr);
+            argv[i] = createStringObjectFromLongLongWithSds((long)old->ptr);
             decrRefCount(old);
         }
     }

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -584,6 +584,19 @@ void asmFeedMigrationClient(robj **argv, int argc) {
     struct redisCommand *cmd = lookupCommandBySds(argv[0]->ptr);
     serverAssert(cmd);
 
+    /* Ensure all arguments are converted to string encoding if necessary,
+     * since getSlotFromCommand expects them to be string-encoded.
+     * Generally the arguments are string-encoded, but we may rewrite
+     * the command arguments to integer encoding. */
+    for (int i = 0; i < argc; i++) {
+        if (!sdsEncodedObject(argv[i])) {
+            serverAssert(argv[i]->encoding == OBJ_ENCODING_INT);
+            robj *old = argv[i];
+            argv[i] = createStringObjectFromLongLongWithSds((long long)old->ptr);
+            decrRefCount(old);
+        }
+    }
+
     int slot = getSlotFromCommand(cmd, argv, argc);
     /* If the command does not have keys, or has crossslot keys, skip it.
      * TODO: revisit this to see if we are okay with this. */

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -554,7 +554,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         }
 
         # update expire time during mirgration
-        R 1 expire $slot0_key 100
+        R 1 setex $slot0_key 100 "a"
         R 1 expire $slot1_key 80
         R 1 expire $slot2_key 60
         R 1 hincrbyfloat $slot2_key "f1" 1


### PR DESCRIPTION
during executing commands, we may rewrite the command arguments to integer encoding, but some `getkeys_proc` expects all arguments to be string-encoded and directly access `argv[i]->ptr`, such as `setGetKeys`, that will cause server crash.

```
int setGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result) {
    keyReference *keys;
    UNUSED(cmd);

    keys = getKeysPrepareResult(result, 1);
    keys[0].pos = 1; /* We always know the position */
    result->numkeys = 1;

    for (int i = 3; i < argc; i++) {
        char *arg = argv[i]->ptr;
        if ((arg[0] == 'g' || arg[0] == 'G') &&
            (arg[1] == 'e' || arg[1] == 'E') &&
            (arg[2] == 't' || arg[2] == 'T') && arg[3] == '\0')
        {
            keys[0].flags = CMD_KEY_RW | CMD_KEY_ACCESS | CMD_KEY_UPDATE;
            return 1;
        }
    }

    keys[0].flags = CMD_KEY_OW | CMD_KEY_UPDATE;
    return 1;
}
```
now we check and convert to string encoding if necessary. Actually, most `getkeys_proc` don't access each argv like `setGetKeys`, so this check and convert is a bit waste. 

And for common commands, such as, `set,setex,getex,expire`, maybe we can create sds string object when rewriting objects instead of converting to `integer`, that doesn't bring memory cost since arguments are transient