### PR TITLE
cluster syncslots sync

### DIFF
--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -692,33 +692,18 @@ asmTask *asmCreateImportTask(const char *task_id, slotRangeArray *slot_ranges, s
     return task;
 }
 
-/* CLUSTER MIGRATION IMPORT SLOTS <numranges> <start-slot end-slot [start-slot end-slot ...]>
+/* CLUSTER MIGRATION IMPORT <start-slot end-slot [start-slot end-slot ...]>
  *
  * Sent by operator to the destination node to start the migration. */
 static void clusterMigrationCommandImport(client *c) {
-    if (c->argc < 7) {
-        addReplyErrorArity(c);
-        return;
-    }
-
-    if (strcasecmp(c->argv[3]->ptr, "slots") != 0) {
-        addReplyError(c, "unknown argument");
-        return;
-    }
-
-    long numranges = 0;
-    if (getRangeLongFromObjectOrReply(c, c->argv[4], 1, CLUSTER_SLOTS, &numranges,
-                                      "invalid number of slot ranges") != C_OK)
-        return;
-
     /* Validate slot range arg count */
-    int remaining = c->argc - 5;
-    if (remaining == 0 || remaining % 2 != 0 || remaining / 2 != numranges) {
+    int remaining = c->argc - 3;
+    if (remaining == 0 || remaining % 2 != 0) {
         addReplyErrorArity(c);
         return;
     }
 
-    slotRangeArray *slot_ranges = parseSlotRangesOrReply(c, c->argc, 5);
+    slotRangeArray *slot_ranges = parseSlotRangesOrReply(c, c->argc, 3);
     if (!slot_ranges) return;
 
     sds err = NULL;
@@ -848,7 +833,7 @@ static void clusterMigrationCommandStatus(client *c) {
 }
 
 /* CLUSTER MIGRATION
- *      <IMPORT SLOTS <numranges> <start-slot end-slot [start-slot end-slot ...]> |
+ *      <IMPORT <start-slot end-slot [start-slot end-slot ...]> |
  *       STATUS [ID <task-id> | ALL] |
  *       CANCEL [ID <task-id> | ALL]>
 */

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -1213,7 +1213,7 @@ write_error: /* Handle sendCommand() errors. */
 }
 
 char *asmSendSlotRangesSync(connection *conn, asmTask *task) {
-    /* Prepare CLUSTER SYNCSLOTS RANGES command */
+    /* Prepare CLUSTER SYNCSLOTS SYNC command */
     serverAssert(task->slot_ranges->num_ranges <= CLUSTER_SLOTS);
     int argc = task->slot_ranges->num_ranges*2 + 4;
     char **args = zcalloc(sizeof(char*) * argc);
@@ -1221,11 +1221,11 @@ char *asmSendSlotRangesSync(connection *conn, asmTask *task) {
 
     args[0] = "CLUSTER";
     args[1] = "SYNCSLOTS";
-    args[2] = "RANGES";
+    args[2] = "SYNC";
     args[3] = task->id;
     lens[0] = strlen("CLUSTER");
     lens[1] = strlen("SYNCSLOTS");
-    lens[2] = strlen("RANGES");
+    lens[2] = strlen("SYNC");
     lens[3] = sdslen(task->id);
 
     int i = 4;
@@ -1350,7 +1350,7 @@ void asmSyncWithSource(connection *conn) {
                 "Source node replied to RDBCHANNELSYNCSLOTS, syncslots can continue...");
         } else {
             task_error_msg = sdscatprintf(sdsempty(),
-                "Error reply to CLUSTER SYNCSLOTS RANGES from the source: %s", err);
+                "Error reply to CLUSTER SYNCSLOTS SYNC from the source: %s", err);
             sdsfree(err);
             goto error;
         }
@@ -1630,8 +1630,8 @@ void clusterSyncSlotsCommand(client *c) {
         }
     }
 
-    if (!strcasecmp(c->argv[2]->ptr, "ranges") && c->argc >= 6) {
-        /* CLUSTER SYNCSLOTS RANGES <ID> <start-slot> <end-slot> [<start-slot> <end-slot>] */
+    if (!strcasecmp(c->argv[2]->ptr, "sync") && c->argc >= 6) {
+        /* CLUSTER SYNCSLOTS SYNC <ID> <start-slot> <end-slot> [<start-slot> <end-slot>] */
         if (c->argc % 2 == 1) {
             addReplyErrorArity(c);
             return;

--- a/src/commands.def
+++ b/src/commands.def
@@ -1070,16 +1070,16 @@ const char *CLUSTER_SYNCSLOTS_Tips[] = {
 #define CLUSTER_SYNCSLOTS_Keyspecs NULL
 #endif
 
-/* CLUSTER SYNCSLOTS subcommand ranges slot_range argument table */
-struct COMMAND_ARG CLUSTER_SYNCSLOTS_subcommand_ranges_slot_range_Subargs[] = {
+/* CLUSTER SYNCSLOTS subcommand sync slot_range argument table */
+struct COMMAND_ARG CLUSTER_SYNCSLOTS_subcommand_sync_slot_range_Subargs[] = {
 {MAKE_ARG("start-slot",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
 {MAKE_ARG("end-slot",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
 };
 
-/* CLUSTER SYNCSLOTS subcommand ranges argument table */
-struct COMMAND_ARG CLUSTER_SYNCSLOTS_subcommand_ranges_Subargs[] = {
+/* CLUSTER SYNCSLOTS subcommand sync argument table */
+struct COMMAND_ARG CLUSTER_SYNCSLOTS_subcommand_sync_Subargs[] = {
 {MAKE_ARG("task-id",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
-{MAKE_ARG("slot-range",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,2,NULL),.subargs=CLUSTER_SYNCSLOTS_subcommand_ranges_slot_range_Subargs},
+{MAKE_ARG("slot-range",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,2,NULL),.subargs=CLUSTER_SYNCSLOTS_subcommand_sync_slot_range_Subargs},
 };
 
 /* CLUSTER SYNCSLOTS subcommand ack argument table */
@@ -1096,7 +1096,7 @@ struct COMMAND_ARG CLUSTER_SYNCSLOTS_subcommand_conf_Subargs[] = {
 
 /* CLUSTER SYNCSLOTS subcommand argument table */
 struct COMMAND_ARG CLUSTER_SYNCSLOTS_subcommand_Subargs[] = {
-{MAKE_ARG("ranges",ARG_TYPE_BLOCK,-1,"RANGES",NULL,NULL,CMD_ARG_NONE,2,NULL),.subargs=CLUSTER_SYNCSLOTS_subcommand_ranges_Subargs},
+{MAKE_ARG("sync",ARG_TYPE_BLOCK,-1,"SYNC",NULL,NULL,CMD_ARG_NONE,2,NULL),.subargs=CLUSTER_SYNCSLOTS_subcommand_sync_Subargs},
 {MAKE_ARG("task-id",ARG_TYPE_STRING,-1,"RDBCHANNEL",NULL,NULL,CMD_ARG_NONE,0,NULL)},
 {MAKE_ARG("snapshot-eof",ARG_TYPE_PURE_TOKEN,-1,"SNAPSHOT-EOF",NULL,NULL,CMD_ARG_NONE,0,NULL)},
 {MAKE_ARG("stream-eof",ARG_TYPE_PURE_TOKEN,-1,"STREAM-EOF",NULL,NULL,CMD_ARG_NONE,0,NULL)},
@@ -1128,7 +1128,7 @@ struct COMMAND_STRUCT CLUSTER_Subcommands[] = {
 {MAKE_CMD("keyslot","Returns the hash slot for a key.","O(N) where N is the number of bytes in the key","3.0.0",CMD_DOC_NONE,NULL,NULL,"cluster",COMMAND_GROUP_CLUSTER,CLUSTER_KEYSLOT_History,0,CLUSTER_KEYSLOT_Tips,0,clusterCommand,3,CMD_STALE,0,CLUSTER_KEYSLOT_Keyspecs,0,NULL,1),.args=CLUSTER_KEYSLOT_Args},
 {MAKE_CMD("links","Returns a list of all TCP links to and from peer nodes.","O(N) where N is the total number of Cluster nodes","7.0.0",CMD_DOC_NONE,NULL,NULL,"cluster",COMMAND_GROUP_CLUSTER,CLUSTER_LINKS_History,0,CLUSTER_LINKS_Tips,1,clusterCommand,2,CMD_STALE,0,CLUSTER_LINKS_Keyspecs,0,NULL,0)},
 {MAKE_CMD("meet","Forces a node to handshake with another node.","O(1)","3.0.0",CMD_DOC_NONE,NULL,NULL,"cluster",COMMAND_GROUP_CLUSTER,CLUSTER_MEET_History,1,CLUSTER_MEET_Tips,0,clusterCommand,-4,CMD_NO_ASYNC_LOADING|CMD_ADMIN|CMD_STALE,0,CLUSTER_MEET_Keyspecs,0,NULL,3),.args=CLUSTER_MEET_Args},
-{MAKE_CMD("migration","Start, monitor and cancel slot migration.","O(N) where N is the total number of the slots between the start slot and end slot arguments.","9.0.0",CMD_DOC_NONE,NULL,NULL,"cluster",COMMAND_GROUP_CLUSTER,CLUSTER_MIGRATION_History,0,CLUSTER_MIGRATION_Tips,0,clusterCommand,-4,CMD_NO_ASYNC_LOADING|CMD_ADMIN|CMD_STALE,0,CLUSTER_MIGRATION_Keyspecs,0,NULL,1),.args=CLUSTER_MIGRATION_Args},
+{MAKE_CMD("migration","Start, monitor and cancel slot migration.","O(N) where N is the total number of the slots between the start slot and end slot arguments.","8.4.0",CMD_DOC_NONE,NULL,NULL,"cluster",COMMAND_GROUP_CLUSTER,CLUSTER_MIGRATION_History,0,CLUSTER_MIGRATION_Tips,0,clusterCommand,-4,CMD_NO_ASYNC_LOADING|CMD_ADMIN|CMD_STALE,0,CLUSTER_MIGRATION_Keyspecs,0,NULL,1),.args=CLUSTER_MIGRATION_Args},
 {MAKE_CMD("myid","Returns the ID of a node.","O(1)","3.0.0",CMD_DOC_NONE,NULL,NULL,"cluster",COMMAND_GROUP_CLUSTER,CLUSTER_MYID_History,0,CLUSTER_MYID_Tips,0,clusterCommand,2,CMD_STALE,0,CLUSTER_MYID_Keyspecs,0,NULL,0)},
 {MAKE_CMD("myshardid","Returns the shard ID of a node.","O(1)","7.2.0",CMD_DOC_NONE,NULL,NULL,"cluster",COMMAND_GROUP_CLUSTER,CLUSTER_MYSHARDID_History,0,CLUSTER_MYSHARDID_Tips,1,clusterCommand,2,CMD_STALE,0,CLUSTER_MYSHARDID_Keyspecs,0,NULL,0)},
 {MAKE_CMD("nodes","Returns the cluster configuration for a node.","O(N) where N is the total number of Cluster nodes","3.0.0",CMD_DOC_NONE,NULL,NULL,"cluster",COMMAND_GROUP_CLUSTER,CLUSTER_NODES_History,0,CLUSTER_NODES_Tips,1,clusterCommand,2,CMD_STALE,0,CLUSTER_NODES_Keyspecs,0,NULL,0)},
@@ -1142,7 +1142,7 @@ struct COMMAND_STRUCT CLUSTER_Subcommands[] = {
 {MAKE_CMD("slaves","Lists the replica nodes of a master node.","O(N) where N is the number of replicas.","3.0.0",CMD_DOC_DEPRECATED,"`CLUSTER REPLICAS`","5.0.0","cluster",COMMAND_GROUP_CLUSTER,CLUSTER_SLAVES_History,0,CLUSTER_SLAVES_Tips,1,clusterCommand,3,CMD_ADMIN|CMD_STALE,0,CLUSTER_SLAVES_Keyspecs,0,NULL,1),.args=CLUSTER_SLAVES_Args},
 {MAKE_CMD("slot-stats","Return an array of slot usage statistics for slots assigned to the current node.","O(N) where N is the total number of slots based on arguments. O(N*log(N)) with ORDERBY subcommand.","8.2.0",CMD_DOC_NONE,NULL,NULL,"cluster",COMMAND_GROUP_CLUSTER,CLUSTER_SLOT_STATS_History,0,CLUSTER_SLOT_STATS_Tips,2,clusterSlotStatsCommand,-4,CMD_STALE|CMD_LOADING,0,CLUSTER_SLOT_STATS_Keyspecs,0,NULL,1),.args=CLUSTER_SLOT_STATS_Args},
 {MAKE_CMD("slots","Returns the mapping of cluster slots to nodes.","O(N) where N is the total number of Cluster nodes","3.0.0",CMD_DOC_DEPRECATED,"`CLUSTER SHARDS`","7.0.0","cluster",COMMAND_GROUP_CLUSTER,CLUSTER_SLOTS_History,2,CLUSTER_SLOTS_Tips,1,clusterCommand,2,CMD_LOADING|CMD_STALE,0,CLUSTER_SLOTS_Keyspecs,0,NULL,0)},
-{MAKE_CMD("syncslots","Internal command for atomic slot migration protocol between cluster nodes.","O(1)","9.0.0",CMD_DOC_NONE,NULL,NULL,"cluster",COMMAND_GROUP_CLUSTER,CLUSTER_SYNCSLOTS_History,0,CLUSTER_SYNCSLOTS_Tips,1,clusterCommand,-3,CMD_NO_ASYNC_LOADING|CMD_ADMIN|CMD_STALE,0,CLUSTER_SYNCSLOTS_Keyspecs,0,NULL,1),.args=CLUSTER_SYNCSLOTS_Args},
+{MAKE_CMD("syncslots","Internal command for atomic slot migration protocol between cluster nodes.","O(1)","8.4.0",CMD_DOC_NONE,NULL,NULL,"cluster",COMMAND_GROUP_CLUSTER,CLUSTER_SYNCSLOTS_History,0,CLUSTER_SYNCSLOTS_Tips,1,clusterCommand,-3,CMD_NO_ASYNC_LOADING|CMD_ADMIN|CMD_STALE,0,CLUSTER_SYNCSLOTS_Keyspecs,0,NULL,1),.args=CLUSTER_SYNCSLOTS_Args},
 {0}
 };
 
@@ -11605,7 +11605,7 @@ struct COMMAND_STRUCT redisCommandTable[] = {
 {MAKE_CMD("swapdb","Swaps two Redis databases.","O(N) where N is the count of clients watching or blocking on keys from both databases.","4.0.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,SWAPDB_History,0,SWAPDB_Tips,0,swapdbCommand,3,CMD_WRITE|CMD_FAST,ACL_CATEGORY_KEYSPACE|ACL_CATEGORY_DANGEROUS,SWAPDB_Keyspecs,0,NULL,2),.args=SWAPDB_Args},
 {MAKE_CMD("sync","An internal command used in replication.",NULL,"1.0.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,SYNC_History,0,SYNC_Tips,0,syncCommand,1,CMD_NO_ASYNC_LOADING|CMD_ADMIN|CMD_NO_MULTI|CMD_NOSCRIPT,0,SYNC_Keyspecs,0,NULL,0)},
 {MAKE_CMD("time","Returns the server time.","O(1)","2.6.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,TIME_History,0,TIME_Tips,1,timeCommand,1,CMD_LOADING|CMD_STALE|CMD_FAST,0,TIME_Keyspecs,0,NULL,0)},
-{MAKE_CMD("trimslots","Trim the keys that belong to specified slots.","O(N) where N is the total number of keys in all databases","9.0.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,TRIMSLOTS_History,0,TRIMSLOTS_Tips,0,trimslotsCommand,-5,CMD_WRITE,ACL_CATEGORY_KEYSPACE|ACL_CATEGORY_DANGEROUS,TRIMSLOTS_Keyspecs,0,NULL,1),.args=TRIMSLOTS_Args},
+{MAKE_CMD("trimslots","Trim the keys that belong to specified slots.","O(N) where N is the total number of keys in all databases","8.4.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,TRIMSLOTS_History,0,TRIMSLOTS_Tips,0,trimslotsCommand,-5,CMD_WRITE,ACL_CATEGORY_KEYSPACE|ACL_CATEGORY_DANGEROUS,TRIMSLOTS_Keyspecs,0,NULL,1),.args=TRIMSLOTS_Args},
 /* set */
 {MAKE_CMD("sadd","Adds one or more members to a set. Creates the key if it doesn't exist.","O(1) for each element added, so O(N) to add N elements when the command is called with multiple arguments.","1.0.0",CMD_DOC_NONE,NULL,NULL,"set",COMMAND_GROUP_SET,SADD_History,1,SADD_Tips,0,saddCommand,-3,CMD_WRITE|CMD_DENYOOM|CMD_FAST,ACL_CATEGORY_SET,SADD_Keyspecs,1,NULL,2),.args=SADD_Args},
 {MAKE_CMD("scard","Returns the number of members in a set.","O(1)","1.0.0",CMD_DOC_NONE,NULL,NULL,"set",COMMAND_GROUP_SET,SCARD_History,0,SCARD_Tips,0,scardCommand,2,CMD_READONLY|CMD_FAST,ACL_CATEGORY_SET,SCARD_Keyspecs,1,NULL,1),.args=SCARD_Args},

--- a/src/commands.def
+++ b/src/commands.def
@@ -700,17 +700,10 @@ struct COMMAND_ARG CLUSTER_MEET_Args[] = {
 #define CLUSTER_MIGRATION_Keyspecs NULL
 #endif
 
-/* CLUSTER MIGRATION subcommand import slot_range argument table */
-struct COMMAND_ARG CLUSTER_MIGRATION_subcommand_import_slot_range_Subargs[] = {
-{MAKE_ARG("start-slot",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
-{MAKE_ARG("end-slot",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
-};
-
 /* CLUSTER MIGRATION subcommand import argument table */
 struct COMMAND_ARG CLUSTER_MIGRATION_subcommand_import_Subargs[] = {
-{MAKE_ARG("slots-keyword",ARG_TYPE_PURE_TOKEN,-1,"SLOTS",NULL,NULL,CMD_ARG_NONE,0,NULL)},
-{MAKE_ARG("numranges",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
-{MAKE_ARG("slot-range",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,2,NULL),.subargs=CLUSTER_MIGRATION_subcommand_import_slot_range_Subargs},
+{MAKE_ARG("start-slot",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("end-slot",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
 };
 
 /* CLUSTER MIGRATION subcommand cancel argument table */
@@ -727,7 +720,7 @@ struct COMMAND_ARG CLUSTER_MIGRATION_subcommand_status_Subargs[] = {
 
 /* CLUSTER MIGRATION subcommand argument table */
 struct COMMAND_ARG CLUSTER_MIGRATION_subcommand_Subargs[] = {
-{MAKE_ARG("import",ARG_TYPE_BLOCK,-1,"IMPORT",NULL,NULL,CMD_ARG_NONE,3,NULL),.subargs=CLUSTER_MIGRATION_subcommand_import_Subargs},
+{MAKE_ARG("import",ARG_TYPE_BLOCK,-1,"IMPORT",NULL,NULL,CMD_ARG_MULTIPLE,2,NULL),.subargs=CLUSTER_MIGRATION_subcommand_import_Subargs},
 {MAKE_ARG("cancel",ARG_TYPE_ONEOF,-1,"CANCEL",NULL,NULL,CMD_ARG_NONE,2,NULL),.subargs=CLUSTER_MIGRATION_subcommand_cancel_Subargs},
 {MAKE_ARG("status",ARG_TYPE_BLOCK,-1,"STATUS",NULL,NULL,CMD_ARG_NONE,2,NULL),.subargs=CLUSTER_MIGRATION_subcommand_status_Subargs},
 };

--- a/src/commands/cluster-migration.json
+++ b/src/commands/cluster-migration.json
@@ -21,30 +21,15 @@
                         "name": "import",
                         "token": "IMPORT",
                         "type": "block",
+                        "multiple": true,
                         "arguments": [
                             {
-                                "name": "slots-keyword",
-                                "token": "SLOTS",
-                                "type": "pure-token"
-                            },
-                            {
-                                "name": "numranges",
+                                "name": "start-slot",
                                 "type": "integer"
                             },
                             {
-                                "name": "slot-range",
-                                "type": "block",
-                                "multiple": true,
-                                "arguments": [
-                                    {
-                                        "name": "start-slot",
-                                        "type": "integer"
-                                    },
-                                    {
-                                        "name": "end-slot",
-                                        "type": "integer"
-                                    }
-                                ]
+                                "name": "end-slot",
+                                "type": "integer"
                             }
                         ]
                     },

--- a/src/commands/cluster-migration.json
+++ b/src/commands/cluster-migration.json
@@ -3,7 +3,7 @@
         "summary": "Start, monitor and cancel slot migration.",
         "complexity": "O(N) where N is the total number of the slots between the start slot and end slot arguments.",
         "group": "cluster",
-        "since": "9.0.0",
+        "since": "8.4.0",
         "arity": -4,
         "container": "CLUSTER",
         "function": "clusterCommand",

--- a/src/commands/cluster-syncslots.json
+++ b/src/commands/cluster-syncslots.json
@@ -3,7 +3,7 @@
         "summary": "Internal command for atomic slot migration protocol between cluster nodes.",
         "complexity": "O(1)",
         "group": "cluster",
-        "since": "9.0.0",
+        "since": "8.4.0",
         "arity": -3,
         "container": "CLUSTER",
         "function": "clusterCommand",
@@ -21,8 +21,8 @@
                 "type": "oneof",
                 "arguments": [
                     {
-                        "name": "ranges",
-                        "token": "RANGES",
+                        "name": "sync",
+                        "token": "SYNC",
                         "type": "block",
                         "arguments": [
                             {
@@ -104,7 +104,7 @@
         "reply_schema": {
             "oneOf": [
                 {
-                    "description": "Reply to CLUSTER SYNCSLOTS RANGES, returns special RDB channel sync response.",
+                    "description": "Reply to CLUSTER SYNCSLOTS SYNC, returns special RDB channel sync response.",
                     "const": "RDBCHANNELSYNCSLOTS"
                 },
                 {

--- a/src/commands/trimslots.json
+++ b/src/commands/trimslots.json
@@ -3,7 +3,7 @@
         "summary": "Trim the keys that belong to specified slots.",
         "complexity": "O(N) where N is the total number of keys in all databases",
         "group": "server",
-        "since": "9.0.0",
+        "since": "8.4.0",
         "arity": -5,
         "function": "trimslotsCommand",
         "command_flags": [

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -156,7 +156,7 @@ proc setup_slot_migration_with_delay {src_node dst_node start_slot end_slot {key
     R $src_node config set rdb-key-save-delay $delay
 
     # migrate slot range from src_node to dst_node
-    set task_id [R $dst_node CLUSTER MIGRATION IMPORT SLOTS 1 $start_slot $end_slot]
+    set task_id [R $dst_node CLUSTER MIGRATION IMPORT $start_slot $end_slot]
     wait_for_condition 2000 10 {
         [string match {*send-bulk-and-stream*} [migration_status $src_node $task_id state]]
     } else {
@@ -170,29 +170,20 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
     test "Test IMPORT input validation" {
         # invalid arguments
         assert_error {*wrong number of arguments*} {R 0 CLUSTER MIGRATION IMPORT}
-        assert_error {*wrong number of arguments*} {R 0 CLUSTER MIGRATION IMPORT SLOTS}
-        assert_error {*wrong number of arguments*} {R 0 CLUSTER MIGRATION IMPORT SLOTS 1}
-        assert_error {*wrong number of arguments*} {R 0 CLUSTER MIGRATION IMPORT SLOTS 1 0}
-        assert_error {*unknown argument*} {R 0 CLUSTER MIGRATION IMPORT ABC 1 0 1}
-        assert_error {*invalid number of slot ranges*} {R 0 CLUSTER MIGRATION IMPORT SLOTS 0 0 1}
-        assert_error {*invalid number of slot ranges*} {R 0 CLUSTER MIGRATION IMPORT SLOTS -1 0 1}
-        assert_error {*invalid number of slot ranges*} {R 0 CLUSTER MIGRATION IMPORT SLOTS 16385 0 1}
-        assert_error {*invalid number of slot ranges*} {R 0 CLUSTER MIGRATION IMPORT SLOTS ABC 0 1}
-        assert_error {*wrong number of arguments*} {R 0 CLUSTER MIGRATION IMPORT SLOTS 1 100}
-        assert_error {*wrong number of arguments*} {R 0 CLUSTER MIGRATION IMPORT SLOTS 1 100 200 300}
-        assert_error {*wrong number of arguments*} {R 0 CLUSTER MIGRATION IMPORT SLOTS 1 100 200 300 400}
+        assert_error {*wrong number of arguments*} {R 0 CLUSTER MIGRATION IMPORT 100}
+        assert_error {*wrong number of arguments*} {R 0 CLUSTER MIGRATION IMPORT 100 200 300}
         # Invalid slot range
-        assert_error {*greater than end slot number*} {R 0 CLUSTER MIGRATION IMPORT SLOTS 1 200 100}
-        assert_error {*out of range slot*} {R 0 CLUSTER MIGRATION IMPORT SLOTS 1 17000 18000}
-        assert_error {*out of range slot*} {R 0 CLUSTER MIGRATION IMPORT SLOTS 1 14000 18000}
-        assert_error {*out of range slot*} {R 0 CLUSTER MIGRATION IMPORT SLOTS 1 -1 0}
-        assert_error {*out of range slot*} {R 0 CLUSTER MIGRATION IMPORT SLOTS 1 sd sd}
+        assert_error {*greater than end slot number*} {R 0 CLUSTER MIGRATION IMPORT 200 100}
+        assert_error {*out of range slot*} {R 0 CLUSTER MIGRATION IMPORT 17000 18000}
+        assert_error {*out of range slot*} {R 0 CLUSTER MIGRATION IMPORT 14000 18000}
+        assert_error {*out of range slot*} {R 0 CLUSTER MIGRATION IMPORT -1 0}
+        assert_error {*out of range slot*} {R 0 CLUSTER MIGRATION IMPORT sd sd}
 
-        assert_error {*already the owner of the slot*} {R 0 CLUSTER MIGRATION IMPORT SLOTS 1 100 200}
+        assert_error {*already the owner of the slot*} {R 0 CLUSTER MIGRATION IMPORT 100 200}
     }
 
     test "Test IMPORT not allowed on replica" {
-        assert_error {* not allowed on replica*} {R 4 CLUSTER MIGRATION IMPORT SLOTS 1 100 200}
+        assert_error {* not allowed on replica*} {R 4 CLUSTER MIGRATION IMPORT 100 200}
     }
 
     test "Test IMPORT not allowed during manual migration" {
@@ -200,39 +191,39 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
 
         # Set a slot to IMPORTING
         R 0 CLUSTER SETSLOT 15000 IMPORTING $dst_id
-        assert_error {*must be STABLE to start*slot migration*} {R 0 CLUSTER MIGRATION IMPORT SLOTS 1 100 200}
+        assert_error {*must be STABLE to start*slot migration*} {R 0 CLUSTER MIGRATION IMPORT 100 200}
         # Revert the change
         R 0 CLUSTER SETSLOT 15000 STABLE
 
         # Same test with setting a slot to MIGRATING
         R 0 CLUSTER SETSLOT 5000 MIGRATING $dst_id
-        assert_error {*must be STABLE to start*slot migration*} {R 0 CLUSTER MIGRATION IMPORT SLOTS 1 100 200}
+        assert_error {*must be STABLE to start*slot migration*} {R 0 CLUSTER MIGRATION IMPORT 100 200}
         # Revert the change
         R 0 CLUSTER SETSLOT 5000 STABLE
     }
 
     test "Test IMPORT not allowed if the node is already the owner" {
-        assert_error {*already the owner of the slot*} {R 0 CLUSTER MIGRATION IMPORT SLOTS 1 100 100}
+        assert_error {*already the owner of the slot*} {R 0 CLUSTER MIGRATION IMPORT 100 100}
     }
 
     test "Test IMPORT not allowed for a slot without an owner" {
         # Slot will have no owner
         R 0 CLUSTER DELSLOTS 5000
 
-        assert_error {*slot has no owner: 5000*} {R 0 CLUSTER MIGRATION IMPORT SLOTS 1 5000 5000}
+        assert_error {*slot has no owner: 5000*} {R 0 CLUSTER MIGRATION IMPORT 5000 5000}
 
         # Revert the change
         R 0 CLUSTER ADDSLOTS 5000
     }
 
     test "Test IMPORT not allowed if slot ranges belong to different nodes" {
-        assert_error {*slots belong to different source nodes*} {R 0 CLUSTER MIGRATION IMPORT SLOTS 1 7000 15000}
-        assert_error {*slots belong to different source nodes*} {R 0 CLUSTER MIGRATION IMPORT SLOTS 2 7000 8000 14000 15000}
+        assert_error {*slots belong to different source nodes*} {R 0 CLUSTER MIGRATION IMPORT 7000 15000}
+        assert_error {*slots belong to different source nodes*} {R 0 CLUSTER MIGRATION IMPORT 7000 8000 14000 15000}
     }
 
     test "Test IMPORT not allowed if slot is given multiple times" {
-        assert_error {*Slot*specified multiple times*} {R 0 CLUSTER MIGRATION IMPORT SLOTS 2 7000 8000 8000 9000}
-        assert_error {*Slot*specified multiple times*} {R 0 CLUSTER MIGRATION IMPORT SLOTS 2 7000 8000 7900 9000}
+        assert_error {*Slot*specified multiple times*} {R 0 CLUSTER MIGRATION IMPORT 7000 8000 8000 9000}
+        assert_error {*Slot*specified multiple times*} {R 0 CLUSTER MIGRATION IMPORT 7000 8000 7900 9000}
     }
 
     test "Test IMPORT not allowed if there is an overlapping import" {
@@ -241,11 +232,11 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         R 1 set tag22273 tag22273 ;# slot hash is 7000
         R 1 set tag9283 tag9283 ;# slot hash is 8000
 
-        set task_id [R 0 CLUSTER MIGRATION IMPORT SLOTS 1 7000 8000]
-        assert_error {*overlapping import exists*} {R 0 CLUSTER MIGRATION IMPORT SLOTS 1 8000 9000}
-        assert_error {*overlapping import exists*} {R 0 CLUSTER MIGRATION IMPORT SLOTS 1 7500 8500}
-        assert_error {*overlapping import exists*} {R 0 CLUSTER MIGRATION IMPORT SLOTS 1 6000 7000}
-        assert_error {*overlapping import exists*} {R 0 CLUSTER MIGRATION IMPORT SLOTS 1 6500 7500}
+        set task_id [R 0 CLUSTER MIGRATION IMPORT 7000 8000]
+        assert_error {*overlapping import exists*} {R 0 CLUSTER MIGRATION IMPORT 8000 9000}
+        assert_error {*overlapping import exists*} {R 0 CLUSTER MIGRATION IMPORT 7500 8500}
+        assert_error {*overlapping import exists*} {R 0 CLUSTER MIGRATION IMPORT 6000 7000}
+        assert_error {*overlapping import exists*} {R 0 CLUSTER MIGRATION IMPORT 6500 7500}
 
         wait_for_condition 1000 50 {
             [string match {*done*} [migration_status 0 $task_id state]] &&
@@ -258,7 +249,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         R 1 config set rdb-key-save-delay 0
 
         # revert the migration
-        R 1 CLUSTER MIGRATION IMPORT SLOTS 1 7000 8000
+        R 1 CLUSTER MIGRATION IMPORT 7000 8000
         wait_for_asm_done
     }
 
@@ -320,9 +311,9 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         }
 
         # Migrate keys
-        R 1 CLUSTER MIGRATION IMPORT SLOTS 1 0 100
+        R 1 CLUSTER MIGRATION IMPORT 0 100
         wait_for_asm_done
-        R 0 CLUSTER MIGRATION IMPORT SLOTS 1 6000 6100
+        R 0 CLUSTER MIGRATION IMPORT 6000 6100
         wait_for_asm_done
 
         stop_write_load $load_handle0
@@ -338,9 +329,9 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         R 1 debug asm-trim-method default
         R 1 flushall
 
-        R 0 CLUSTER MIGRATION IMPORT SLOTS 1 0 100
+        R 0 CLUSTER MIGRATION IMPORT 0 100
         wait_for_asm_done
-        R 1 CLUSTER MIGRATION IMPORT SLOTS 1 6000 6100
+        R 1 CLUSTER MIGRATION IMPORT 6000 6100
         wait_for_asm_done
     }
 
@@ -360,7 +351,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         }
 
         # migrate slot 0-100 to R 1
-        set task_id [R 1 CLUSTER MIGRATION IMPORT SLOTS 1 0 100]
+        set task_id [R 1 CLUSTER MIGRATION IMPORT 0 100]
         # migration is start, and in accumulating buffer stage
         wait_for_condition 1000 50 {
             [string match {*send-bulk-and-stream*} [migration_status 0 $task_id state]] &&
@@ -434,7 +425,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
             }
 
             # Start the migration
-            set task_id [R 0 CLUSTER MIGRATION IMPORT SLOTS 1 0 100]
+            set task_id [R 0 CLUSTER MIGRATION IMPORT 0 100]
 
             # The task should be failed due to the fail point
             wait_for_condition 1000 50 {
@@ -511,7 +502,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         assert_equal {OK} [R 1 debug asm-failpoint "" ""]
 
         # Start the migration
-        set task_id [R 0 CLUSTER MIGRATION IMPORT SLOTS 1 0 100]
+        set task_id [R 0 CLUSTER MIGRATION IMPORT 0 100]
 
         # Wait for the migration to complete
         wait_for_asm_done
@@ -538,7 +529,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         # we set a delay to write incremental data
         R 0 config set rdb-key-save-delay 1000000
 
-        set task_id [R 1 CLUSTER MIGRATION IMPORT SLOTS 1 0 100]
+        set task_id [R 1 CLUSTER MIGRATION IMPORT 0 100]
 
         wait_for_condition 1000 50 {
             [string match {*send-bulk-and-stream*} [migration_status 0 $task_id state]]
@@ -595,7 +586,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         R 1 expire $slot2_key 2
         R 1 hexpire $slot2_key 2 FIELDS 1 "f1"
 
-        set task_id [R 0 CLUSTER MIGRATION IMPORT SLOTS 1 0 100]
+        set task_id [R 0 CLUSTER MIGRATION IMPORT 0 100]
         wait_for_condition 2000 10 {
             [string match {*send-bulk-and-stream*} [migration_status 1 $task_id state]]
         } else {
@@ -700,7 +691,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         R 0 set $slot1_key $1m_str
         R 0 set $slot2_key $1m_str
 
-        set task_id [R 1 CLUSTER MIGRATION IMPORT SLOTS 1 0 100]
+        set task_id [R 1 CLUSTER MIGRATION IMPORT 0 100]
         wait_for_condition 2000 10 {
             [string match {*send-bulk-and-stream*} [migration_status 0 $task_id state]]
         } else {
@@ -752,7 +743,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
 
         # We can restart ASM tasks on new master, migrate slot 0-100 from 1 to 3
         R 1 config set rdb-key-save-delay 0
-        set task_id [R 3 CLUSTER MIGRATION IMPORT SLOTS 1 0 100]
+        set task_id [R 3 CLUSTER MIGRATION IMPORT 0 100]
         wait_for_asm_done
 
         # migrate slot 0-100 from 3 to 1
@@ -879,7 +870,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
     test "CLUSTER FORGET command cancels a slot migration task" {
         R 0 config set rdb-key-save-delay 0
         # Migrate all slot on #0 to #1, so we can forget #0
-        set task_id [R 1 CLUSTER MIGRATION IMPORT SLOTS 1 0 5461]
+        set task_id [R 1 CLUSTER MIGRATION IMPORT 0 5461]
         wait_for_asm_done
 
         # start slot migration from 1 to 0
@@ -930,7 +921,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         }
 
         # start task again
-        set task_id [R 1 CLUSTER MIGRATION IMPORT SLOTS 1 0 100]
+        set task_id [R 1 CLUSTER MIGRATION IMPORT 0 100]
         after 200 ;# give some time to have chance to schedule the task
         # the task should not start since server is paused
         assert {[string match {*none*} [migration_status 1 $task_id state]]}
@@ -942,7 +933,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         # migrate back to original node #0
         R 0 config set rdb-key-save-delay 0
         R 1 config set rdb-key-save-delay 0
-        R 0 CLUSTER MIGRATION IMPORT SLOTS 1 0 100
+        R 0 CLUSTER MIGRATION IMPORT 0 100
         wait_for_asm_done
     }
 
@@ -1061,7 +1052,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         R 0 config set rdb-key-save-delay 10000 ;# 1000 keys cost 10s to save
 
         # start migration from #0 to #1
-        set task_id [R 1 CLUSTER MIGRATION IMPORT SLOTS 1 0 100]
+        set task_id [R 1 CLUSTER MIGRATION IMPORT 0 100]
         wait_for_condition 1000 20 {
             [string match {*send-bulk-and-stream*} [migration_status 0 $task_id state]]
         } else {
@@ -1210,7 +1201,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         # Fill slot 0 on node-0 and migrate it to node-1
         R 0 flushall
         populate_slot 10000 -idx 0 -slot 0
-        R 1 CLUSTER MIGRATION IMPORT SLOTS 1 0 100
+        R 1 CLUSTER MIGRATION IMPORT 0 100
         wait_for_asm_done
 
         # Verify the data is migrated
@@ -1231,7 +1222,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         }
 
         # Cleanup
-        R 0 CLUSTER MIGRATION IMPORT SLOTS 1 0 100
+        R 0 CLUSTER MIGRATION IMPORT 0 100
         wait_for_asm_done
         R 0 flushall
         R 0 debug asm-trim-method default
@@ -1300,7 +1291,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         wait_for_blocked_clients_count 2
 
         # Migrate slot 0
-        R 1 CLUSTER MIGRATION IMPORT SLOTS 1 0 0
+        R 1 CLUSTER MIGRATION IMPORT 0 0
         wait_for_asm_done
 
         # First client should get MOVED error
@@ -1315,7 +1306,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
 
         # cleanup
         wait_for_asm_done
-        R 0 CLUSTER MIGRATION IMPORT SLOTS 1 0 0
+        R 0 CLUSTER MIGRATION IMPORT 0 0
         wait_for_asm_done
         R 0 flushall
         R 0 debug asm-trim-method default
@@ -1328,7 +1319,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         set key0 [slot_key 0 key]
         R 0 set $key0 30
         R 0 watch $key0
-        R 1 CLUSTER MIGRATION IMPORT SLOTS 1 0 0
+        R 1 CLUSTER MIGRATION IMPORT 0 0
         wait_for_asm_done
         R 0 multi
         R 0 ping
@@ -1338,7 +1329,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         set key2 [slot_key 2 key]
         R 0 set $key2 30
         R 0 watch $key2
-        R 1 CLUSTER MIGRATION IMPORT SLOTS 1 1 1
+        R 1 CLUSTER MIGRATION IMPORT 1 1
         wait_for_asm_done
         R 0 multi
         R 0 ping
@@ -1346,7 +1337,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
 
         # cleanup
         wait_for_asm_done
-        R 0 CLUSTER MIGRATION IMPORT SLOTS 1 0 1
+        R 0 CLUSTER MIGRATION IMPORT 0 1
         wait_for_asm_done
         R 0 flushall
         R 0 debug asm-trim-method default
@@ -1365,7 +1356,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         R 0 CLIENT TRACKING on REDIRECT $redir_id
         R 0 SET $key0 1
         R 0 GET $key0
-        R 1 CLUSTER MIGRATION IMPORT SLOTS 1 0 0
+        R 1 CLUSTER MIGRATION IMPORT 0 0
         wait_for_asm_done
 
         # Verify the tracking client received the invalidation message
@@ -1375,7 +1366,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         # cleanup
         $rd_redirection close
         wait_for_asm_done
-        R 0 CLUSTER MIGRATION IMPORT SLOTS 1 0 0
+        R 0 CLUSTER MIGRATION IMPORT 0 0
         wait_for_asm_done
         R 0 flushall
     }
@@ -1448,7 +1439,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         populate_slot 500 -slot 4
 
         # Migrate 1500 keys
-        R 1 CLUSTER MIGRATION IMPORT SLOTS 2 0 1 3 3
+        R 1 CLUSTER MIGRATION IMPORT 0 1 3 3
         wait_for_asm_done
 
         wait_for_condition 1000 10 {
@@ -1476,7 +1467,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         # cleanup
         R 0 debug asm-trim-method default
         R 3 debug asm-trim-method default
-        R 0 CLUSTER MIGRATION IMPORT SLOTS 2 0 1 3 3
+        R 0 CLUSTER MIGRATION IMPORT 0 1 3 3
         wait_for_asm_done
         R 0 flushall
         R 1 flushall
@@ -1493,7 +1484,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         populate_slot 500 -slot 4
 
         # Migrate 1500 keys
-        R 1 CLUSTER MIGRATION IMPORT SLOTS 1 0 1
+        R 1 CLUSTER MIGRATION IMPORT 0 1
         wait_for_condition 1000 10 {
             [CI 0 cluster_slot_migration_task_count] == 0 &&
             [CI 0 cluster_slot_migration_active_trim_jobs] == 1 &&
@@ -1503,7 +1494,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         }
 
         # Migrate another slot and verify there are two trim tasks on the source
-        R 1 CLUSTER MIGRATION IMPORT SLOTS 1 3 3
+        R 1 CLUSTER MIGRATION IMPORT 3 3
         wait_for_condition 1000 10 {
             [CI 0 cluster_slot_migration_task_count] == 0 &&
             [CI 0 cluster_slot_migration_active_trim_jobs] == 2 &&
@@ -1527,7 +1518,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         # cleanup
         R 0 debug asm-trim-method default
         R 3 debug asm-trim-method default
-        R 0 CLUSTER MIGRATION IMPORT SLOTS 2 0 1 3 3
+        R 0 CLUSTER MIGRATION IMPORT 0 1 3 3
         wait_for_asm_done
         R 0 flushall
         R 1 flushall
@@ -1544,7 +1535,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         populate_slot 250 -slot 3
         populate_slot 250 -slot 4
 
-        R 1 CLUSTER MIGRATION IMPORT SLOTS 1 0 100
+        R 1 CLUSTER MIGRATION IMPORT 0 100
         after 2000
         R 1 CLUSTER MIGRATION CANCEL ALL
         wait_for_asm_done
@@ -1578,7 +1569,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         set prev_trim_started_1 [CI 1 cluster_slot_migration_active_trim_started]
         set prev_trim_started_4 [CI 4 cluster_slot_migration_active_trim_started]
 
-        R 1 CLUSTER MIGRATION IMPORT SLOTS 1 0 100
+        R 1 CLUSTER MIGRATION IMPORT 0 100
         after 2000
         R 4 CLUSTER FAILOVER
         wait_for_failover 4
@@ -1611,7 +1602,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         populate_slot 500 -slot 1
 
         # Migrate 1500 keys
-        R 1 CLUSTER MIGRATION IMPORT SLOTS 1 0 1
+        R 1 CLUSTER MIGRATION IMPORT 0 1
         wait_for_condition 1000 10 {
             [CI 0 cluster_slot_migration_task_count] == 0 &&
             [CI 0 cluster_slot_migration_active_trim_jobs] == 1
@@ -1620,7 +1611,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         }
 
         # Try to migrate another slots back
-        R 0 CLUSTER MIGRATION IMPORT SLOTS 1 0 1
+        R 0 CLUSTER MIGRATION IMPORT 0 1
         wait_for_log_messages 0 {"*Can not start import task for slots: 0-1 since trim in progress for some of the slots*"} 0 1000 10
 
         # Enabled active trim and verify slots are imported back
@@ -1652,7 +1643,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         populate_slot 5000 -idx 0 -slot 2
 
         # Start migration and wait until trim is in progress
-        R 1 CLUSTER MIGRATION IMPORT SLOTS 1 0 1
+        R 1 CLUSTER MIGRATION IMPORT 0 1
         wait_for_condition 1000 10 {
             [CI 0 cluster_slot_migration_task_count] == 0 &&
             [CI 0 cluster_slot_migration_active_trim_jobs] == 1 &&
@@ -1680,7 +1671,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         R 0 flushall
         R 1 flushall
         R 0 save
-        R 0 CLUSTER MIGRATION IMPORT SLOTS 1 0 1
+        R 0 CLUSTER MIGRATION IMPORT 0 1
         wait_for_asm_done
     }
 
@@ -1695,7 +1686,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         populate_slot 5000 -idx 0 -slot 1
         populate_slot 5000 -idx 0 -slot 2
 
-        R 1 CLUSTER MIGRATION IMPORT SLOTS 1 0 1
+        R 1 CLUSTER MIGRATION IMPORT 0 1
         wait_for_condition 1000 10 {
             [CI 0 cluster_slot_migration_task_count] == 0 &&
             [CI 0 cluster_slot_migration_active_trim_jobs] == 1
@@ -1730,7 +1721,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         R 0 flushall
         R 1 flushall
         R 0 save
-        R 0 CLUSTER MIGRATION IMPORT SLOTS 1 0 1
+        R 0 CLUSTER MIGRATION IMPORT 0 1
         wait_for_asm_done
     }
 
@@ -1740,7 +1731,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         R 0 flushall
         populate_slot 10000 -idx 0 -slot 0
 
-        R 1 CLUSTER MIGRATION IMPORT SLOTS 1 0 100
+        R 1 CLUSTER MIGRATION IMPORT 0 100
         wait_for_condition 1000 10 {
             [CI 0 cluster_slot_migration_task_count] == 0 &&
             [CI 0 cluster_slot_migration_active_trim_jobs] == 1
@@ -1763,7 +1754,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         assert_equal 0 [R 0 dbsize]
 
         # revert
-        R 0 CLUSTER MIGRATION IMPORT SLOTS 1 0 100
+        R 0 CLUSTER MIGRATION IMPORT 0 100
         wait_for_asm_done
         assert_equal 10000 [R 0 dbsize]
     }
@@ -1777,7 +1768,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
             R 0 config set repl-diskless-sync-delay 0
             populate_slot 10000 -idx 0 -slot 0
 
-            R 1 CLUSTER MIGRATION IMPORT SLOTS 1 0 100
+            R 1 CLUSTER MIGRATION IMPORT 0 100
             wait_for_condition 1000 10 {
                 [CI 0 cluster_slot_migration_task_count] == 0 &&
                 [CI 0 cluster_slot_migration_active_trim_jobs] == 0 &&
@@ -1789,7 +1780,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
                 fail "trim failed"
             }
 
-            R 0 CLUSTER MIGRATION IMPORT SLOTS 1 0 100
+            R 0 CLUSTER MIGRATION IMPORT 0 100
             wait_for_condition 1000 10 {
                 [CI 0 cluster_slot_migration_task_count] == 0 &&
                 [CI 0 cluster_slot_migration_active_trim_jobs] == 0 &&
@@ -1831,7 +1822,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
        populate_slot 100 -slot 0
 
        # Wait until active trim is in progress on replica
-       R 1 CLUSTER MIGRATION IMPORT SLOTS 1 0 100
+       R 1 CLUSTER MIGRATION IMPORT 0 100
        wait_for_condition 1000 10 {
            [CI 0 cluster_slot_migration_task_count] == 0 &&
            [CI 0 cluster_slot_migration_active_trim_jobs] == 0 &&
@@ -1844,7 +1835,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
        }
 
        # Get slots back
-       R 0 CLUSTER MIGRATION IMPORT SLOTS 1 0 100
+       R 0 CLUSTER MIGRATION IMPORT 0 100
        wait_for_condition 1000 20 {
            [CI 0 cluster_slot_migration_task_count] == 1 &&
            [CI 0 cluster_slot_migration_active_trim_jobs] == 0 &&
@@ -1945,7 +1936,7 @@ start_cluster 3 3 [list tags {external:skip cluster modules} config_lines [list 
         # cleanup
         R 0 debug asm-trim-method default
         R 3 debug asm-trim-method default
-        R 0 CLUSTER MIGRATION IMPORT SLOTS 1 0 100
+        R 0 CLUSTER MIGRATION IMPORT 0 100
         wait_for_asm_done
         R 0 flushall
         R 1 flushall
@@ -1962,7 +1953,7 @@ start_cluster 3 3 [list tags {external:skip cluster modules} config_lines [list 
             R 0 set $key "value"
 
             # Migrate the slot ranges
-            set task_id [R 1 CLUSTER MIGRATION IMPORT SLOTS 2 0 100 200 300]
+            set task_id [R 1 CLUSTER MIGRATION IMPORT 0 100 200 300]
             wait_for_ofs_sync [Rn 0] [Rn 3]
             wait_for_asm_done
 
@@ -1994,7 +1985,7 @@ start_cluster 3 3 [list tags {external:skip cluster modules} config_lines [list 
             assert_equal $trim_event_log [R 3 asm.get_cluster_trim_event_log]
 
             # cleanup
-            R 0 CLUSTER MIGRATION IMPORT SLOTS 2 0 100 200 300
+            R 0 CLUSTER MIGRATION IMPORT 0 100 200 300
             wait_for_asm_done
             clear_module_event_log
             R 0 debug asm-trim-method default
@@ -2083,7 +2074,7 @@ start_cluster 3 3 [list tags {external:skip cluster modules} config_lines [list 
 
         # cleanup
         R 0 asm.replicate_module_command 0 "" ""
-        R 0 CLUSTER MIGRATION IMPORT SLOTS 1 0 100
+        R 0 CLUSTER MIGRATION IMPORT 0 100
         wait_for_asm_done
         R 0 flushall
         R 1 flushall


### PR DESCRIPTION
- `CLUSTER SYNCSLOTS RANGES <ID> <start-slot> <end-slot> [<start-slot> <end-slot>]` command, we not only pass slot ranges, and this command actually triggers a slot sync, so i think `SYNC` word is better

- Revert cluster migration import