### PR TITLE
trimslots only trim the slot that this node is not serving

### DIFF
--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -2804,6 +2804,18 @@ void trimslotsCommand(client *c) {
          * trimmed. We have to trim the keys synchronously. */
         clusterDelKeysInSlotRangeArray(slots, 1);
     } else {
+        /* We can not trim the slot that this node is serving. */
+        if (clusterNodeIsMaster(getMyClusterNode())) {
+            for (int i = 0; i < slots->num_ranges; i++) {
+                for (int j = slots->ranges[i].start; j <= slots->ranges[i].end; j++) {
+                    if (clusterCanAccessKeysInSlot(j)) {
+                        addReplyErrorFormat(c, "the slot %d is served by this node", j);
+                        slotRangeArrayFree(slots);
+                        return;
+                    }
+                }
+            }
+        }
         asmTrimSlots(slots);
     }
 

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -1873,6 +1873,13 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
        assert_equal 0 [R 1 dbsize]
        assert_equal 0 [R 4 dbsize]
     }
+
+    test "TRIMSLOTS should not trim slots that this node is serving" {
+        assert_error {*the slot 0 is served by this node*} {R 0 trimslots ranges 1 0 0}
+        assert_error {*READONLY*} {R 3 trimslots ranges 1 0 100}
+        assert_equal {OK} [R 0 trimslots ranges 1 16383 16383]
+        assert_error {*READONLY*} {R 3 trimslots ranges 1 16383 16383}
+    }
 }
 
 set testmodule [file normalize tests/modules/atomicslotmigration.so]


### PR DESCRIPTION
I think users may use this command to clear dirty data, so let us check if it is ok to trim