### PR TITLE
keep last error of ASM task

### DIFF
--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -323,8 +323,6 @@ void asmTaskReset(asmTask *task) {
     task->source_offset = 0;
     task->stream_eof_during_streaming = 0;
     replDataBufInit(&task->sync_buffer);
-    sdsfree(task->error);
-    task->error = sdsempty();
     task->main_channel_client = NULL;
     task->rdb_channel_client = NULL;
     task->paused_time = 0;
@@ -2519,8 +2517,12 @@ int asmNotifyConfigUpdated(asmTask *task, sds *err) {
         return C_ERR;
     }
 
-    task->state = ASM_DONE;
     asmNotifyStateChange(task, event);
+
+    /* Clear error message if successful. */
+    sdsfree(task->error);
+    task->error = sdsempty();
+    task->state = ASM_DONE;
     asmTaskComplete(task);
 
     /* Trim the slots after the migrate task is done. */

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -2517,12 +2517,12 @@ int asmNotifyConfigUpdated(asmTask *task, sds *err) {
         return C_ERR;
     }
 
-    asmNotifyStateChange(task, event);
-
     /* Clear error message if successful. */
     sdsfree(task->error);
     task->error = sdsempty();
     task->state = ASM_DONE;
+
+    asmNotifyStateChange(task, event);
     asmTaskComplete(task);
 
     /* Trim the slots after the migrate task is done. */

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -439,13 +439,14 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
                       src: [migration_status 1 $task_id last_error]
                       expected: $channel $state)"
             }
-            R 1 config set rdb-key-save-delay 0
-            R 0 config set key-load-delay 0
             stop_write_load $load_handle
 
             # Cancel the task
             R 0 CLUSTER MIGRATION CANCEL ID $task_id
             R 1 CLUSTER MIGRATION CANCEL ID $task_id
+
+            R 1 config set rdb-key-save-delay 0
+            R 0 config set key-load-delay 0
         }
     }
 


### PR DESCRIPTION
I also not sure if we should clear last error when successful, but i feel it doesn't look consistent to keep error if task is successful.