### PR TITLE
Add source and destination node ids to RedisModuleClusterAsmMigration…

### DIFF
--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -857,10 +857,12 @@ void clusterMigrationCommand(client *c) {
 /* Notify the state change to the module and the plugin. */
 void asmNotifyStateChange(asmTask *task, int state) {
     RedisModuleClusterAsmMigrationInfo info = {
-            REDISMODULE_CLUSTER_ASM_MIGRATIONINFO_VERSION,
-            task->id,
-            (RedisModuleSlotRangeArray *) task->slot_ranges
+            .version = REDISMODULE_CLUSTER_ASM_MIGRATIONINFO_VERSION,
+            .task_id = task->id,
+            .slots = (RedisModuleSlotRangeArray *) task->slot_ranges
     };
+    memcpy(info.source_node_id, task->source, CLUSTER_NAMELEN);
+    memcpy(info.destination_node_id, task->dest, CLUSTER_NAMELEN);
 
     int module_event = -1;
     if (state == ASM_EVENT_IMPORT_STARTED) module_event = REDISMODULE_SUBEVENT_CLUSTER_ASM_IMPORT_STARTED;
@@ -1930,10 +1932,12 @@ static int slotSnapshotSaveKeyValuePair(rio *rdb, kvobj *o, int dbid) {
  * triggers the event, collects the commands and writes them to the rio. */
 static int propagateModuleCommands(asmTask *task, rio *rdb) {
     RedisModuleClusterAsmMigrationInfo info = {
-            REDISMODULE_CLUSTER_ASM_MIGRATIONINFO_VERSION,
-            task->id,
-            (RedisModuleSlotRangeArray *) task->slot_ranges
+            .version = REDISMODULE_CLUSTER_ASM_MIGRATIONINFO_VERSION,
+            .task_id = task->id,
+            .slots = (RedisModuleSlotRangeArray *) task->slot_ranges
     };
+    memcpy(info.source_node_id, task->source, CLUSTER_NAMELEN);
+    memcpy(info.destination_node_id, task->dest, CLUSTER_NAMELEN);
 
     task->module_commands = zcalloc(sizeof(*task->module_commands));
     moduleFireServerEvent(REDISMODULE_EVENT_CLUSTER_ASM,

--- a/src/module.c
+++ b/src/module.c
@@ -11999,7 +11999,8 @@ static uint64_t moduleEventVersions[] = {
  *
  *     The data pointer can be casted to a RedisModuleClusterAsmMigrationInfo
  *     structure with the following fields:
- *
+ *         char source_node_id[REDISMODULE_NODE_ID_LEN + 1];
+ *         char destination_node_id[REDISMODULE_NODE_ID_LEN + 1];
  *         const char *task_id;               // Task ID
  *         RedisModuleSlotRangeArray* slots;  // Slot ranges
  *

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -719,7 +719,7 @@ static const RedisModuleEvent
 #define REDISMODULE_SUBEVENT_CLUSTER_ASM_TRIM_STARTED 0
 #define REDISMODULE_SUBEVENT_CLUSTER_ASM_TRIM_COMPLETED 1
 #define REDISMODULE_SUBEVENT_CLUSTER_ASM_TRIM_BACKGROUND 2
-#define _REDISMODULE_SUBEVENT_CLUSTER_TRIM_NEXT 3
+#define _REDISMODULE_SUBEVENT_CLUSTER_ASM_TRIM_NEXT 3
 
 /* RedisModuleClientInfo flags. */
 #define REDISMODULE_CLIENTINFO_FLAG_SSL (1<<0)
@@ -866,8 +866,10 @@ typedef struct RedisModuleClusterAsmMigrationInfo {
     uint64_t version;       /* Not used since this structure is never passed
                                from the module to the core right now. Here
                                for future compatibility. */
+    char source_node_id[REDISMODULE_NODE_ID_LEN + 1];
+    char destination_node_id[REDISMODULE_NODE_ID_LEN + 1];
     const char *task_id;
-    RedisModuleSlotRangeArray* slots;
+    RedisModuleSlotRangeArray *slots;
 } RedisModuleClusterAsmMigrationInfoV1;
 
 #define RedisModuleClusterAsmMigrationInfo RedisModuleClusterAsmMigrationInfoV1
@@ -878,7 +880,7 @@ typedef struct RedisModuleClusterAsmTrimInfo {
     uint64_t version;       /* Not used since this structure is never passed
                                from the module to the core right now. Here
                                for future compatibility. */
-    RedisModuleSlotRangeArray* slots;
+    RedisModuleSlotRangeArray *slots;
 } RedisModuleClusterAsmTrimInfoV1;
 
 #define RedisModuleClusterAsmTrimInfo RedisModuleClusterAsmTrimInfoV1

--- a/tests/modules/atomicslotmigration.c
+++ b/tests/modules/atomicslotmigration.c
@@ -115,6 +115,8 @@ const char *clusterMigrationInfoToString(RedisModuleClusterAsmMigrationInfo *inf
     else {
         RedisModule_Assert(0);
     }
+    snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), "source_node_id:%.40s, destination_node_id:%.40s, ",
+             info->source_node_id, info->destination_node_id);
     snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), "task_id:%s, slots:", info->task_id);
     for (int i = 0; i < info->slots->num_ranges; i++) {
         RedisModuleSlotRange *sr = &info->slots->ranges[i];

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -1974,16 +1974,19 @@ start_cluster 3 3 [list tags {external:skip cluster modules} config_lines [list 
             wait_for_ofs_sync [Rn 0] [Rn 3]
             wait_for_asm_done
 
+            set src_id [R 0 cluster myid]
+            set dest_id [R 1 cluster myid]
+
             # Verify the events on source
             assert_equal [list \
-                "sub: cluster-asm-migrate-started, task_id:$task_id, slots:0-100,200-300" \
-                "sub: cluster-asm-migrate-completed, task_id:$task_id, slots:0-100,200-300" \
+                "sub: cluster-asm-migrate-started, source_node_id:$src_id, destination_node_id:$dest_id, task_id:$task_id, slots:0-100,200-300" \
+                "sub: cluster-asm-migrate-completed, source_node_id:$src_id, destination_node_id:$dest_id, task_id:$task_id, slots:0-100,200-300" \
             ] [R 0 asm.get_cluster_event_log]
 
             # Verify the events on destination
             assert_equal [list \
-                "sub: cluster-asm-import-started, task_id:$task_id, slots:0-100,200-300" \
-                "sub: cluster-asm-import-completed, task_id:$task_id, slots:0-100,200-300" \
+                "sub: cluster-asm-import-started, source_node_id:$src_id, destination_node_id:$dest_id, task_id:$task_id, slots:0-100,200-300" \
+                "sub: cluster-asm-import-completed, source_node_id:$src_id, destination_node_id:$dest_id, task_id:$task_id, slots:0-100,200-300" \
             ] [R 1 asm.get_cluster_event_log]
 
             # Verify the trim events
@@ -2026,16 +2029,19 @@ start_cluster 3 3 [list tags {external:skip cluster modules} config_lines [list 
             wait_for_asm_done
             wait_for_ofs_sync [Rn 0] [Rn 3]
 
+            set src_id [R 0 cluster myid]
+            set dest_id [R 1 cluster myid]
+
             # Verify the events on source
             assert_equal [list \
-                "sub: cluster-asm-migrate-started, task_id:$task_id, slots:0-100" \
-                "sub: cluster-asm-migrate-failed, task_id:$task_id, slots:0-100" \
+                "sub: cluster-asm-migrate-started, source_node_id:$src_id, destination_node_id:$dest_id, task_id:$task_id, slots:0-100" \
+                "sub: cluster-asm-migrate-failed, source_node_id:$src_id, destination_node_id:$dest_id, task_id:$task_id, slots:0-100" \
             ] [R 0 asm.get_cluster_event_log]
 
             # Verify the events on destination
             assert_equal [list \
-                "sub: cluster-asm-import-started, task_id:$task_id, slots:0-100" \
-                "sub: cluster-asm-import-failed, task_id:$task_id, slots:0-100" \
+                "sub: cluster-asm-import-started, source_node_id:$src_id, destination_node_id:$dest_id, task_id:$task_id, slots:0-100" \
+                "sub: cluster-asm-import-failed, source_node_id:$src_id, destination_node_id:$dest_id, task_id:$task_id, slots:0-100" \
             ] [R 1 asm.get_cluster_event_log]
 
             # Verify the trim events on destination (partially imported keys are trimmed)


### PR DESCRIPTION
…Info

@ShooterIT shall we add source and dest node ids to migration info? Otherwise, it feels we just inform module partially. Wdyt? 