### PR TITLE
Minor fixes

### DIFF
--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -298,15 +298,15 @@ sds asmCatInfoString(sds info) {
     }
 
     return sdscatprintf(info ? info : sdsempty(),
-                        "cluster_slot_migration_task_count:%d\r\n"
-                        "cluster_slot_migration_total_done_tasks:%lld\r\n"
-                        "cluster_slot_migration_sync_buffer_peak:%zu\r\n"
-                        "cluster_slot_migration_active_trim_jobs:%lu\r\n"
-                        "cluster_slot_migration_active_trim_started:%llu\r\n"
-                        "cluster_slot_migration_active_trim_done:%llu\r\n"
-                        "cluster_slot_migration_active_trim_cancelled:%llu\r\n"
-                        "cluster_slot_migration_active_trim_current_job_keys:%llu\r\n"
-                        "cluster_slot_migration_active_trim_current_job_trimmed:%llu\r\n",
+                        "slot_migration_task_count:%d\r\n"
+                        "slot_migration_total_done_tasks:%lld\r\n"
+                        "slot_migration_sync_buffer_peak:%zu\r\n"
+                        "slot_migration_active_trim_jobs:%lu\r\n"
+                        "slot_migration_active_trim_started:%llu\r\n"
+                        "slot_migration_active_trim_done:%llu\r\n"
+                        "slot_migration_active_trim_cancelled:%llu\r\n"
+                        "slot_migration_active_trim_current_job_keys:%llu\r\n"
+                        "slot_migration_active_trim_current_job_trimmed:%llu\r\n",
                         active_tasks,
                         asmManager->total_done_tasks,
                         asmGetPeakSyncBufferSize(),

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -67,11 +67,11 @@ struct asmManager {
     int debug_active_trim_delay;  /* Sleep before trimming each key */
 
     /* Active trim stats */
-    unsigned long long active_trim_started;      /* Number of times active trim was started */
-    unsigned long long active_trim_done;         /* Number of times active trim was completed */
-    unsigned long long active_trim_cancelled;    /* Number of times active trim was cancelled */
-    unsigned long long active_trim_keys_total;   /* Total number of keys to trim in the current job */
-    unsigned long long active_trim_keys_deleted; /* Number of keys trimmed in the current job */
+    unsigned long long active_trim_started;             /* Number of times active trim was started */
+    unsigned long long active_trim_done;                /* Number of times active trim was completed */
+    unsigned long long active_trim_cancelled;           /* Number of times active trim was cancelled */
+    unsigned long long active_trim_current_job_keys;    /* Total number of keys to trim in the current job */
+    unsigned long long active_trim_current_job_trimmed; /* Number of keys trimmed in the current job */
 };
 
 enum asmState {
@@ -305,8 +305,8 @@ sds asmCatInfoString(sds info) {
                         "cluster_slot_migration_active_trim_started:%llu\r\n"
                         "cluster_slot_migration_active_trim_done:%llu\r\n"
                         "cluster_slot_migration_active_trim_cancelled:%llu\r\n"
-                        "cluster_slot_migration_active_trim_keys_total:%llu\r\n"
-                        "cluster_slot_migration_active_trim_keys_deleted:%llu\r\n",
+                        "cluster_slot_migration_active_trim_current_job_keys:%llu\r\n"
+                        "cluster_slot_migration_active_trim_current_job_trimmed:%llu\r\n",
                         active_tasks,
                         asmManager->total_done_tasks,
                         asmGetPeakSyncBufferSize(),
@@ -314,8 +314,8 @@ sds asmCatInfoString(sds info) {
                         asmManager->active_trim_started,
                         asmManager->active_trim_done,
                         asmManager->active_trim_cancelled,
-                        asmManager->active_trim_keys_total,
-                        asmManager->active_trim_keys_deleted);
+                        asmManager->active_trim_current_job_keys,
+                        asmManager->active_trim_current_job_trimmed);
 }
 
 void asmTaskReset(asmTask *task) {
@@ -584,10 +584,6 @@ void asmFeedMigrationClient(robj **argv, int argc) {
     if (task->operation != ASM_MIGRATE) return;
     if (task->state == ASM_FAILED || task->cross_slot_during_propagating) return;
 
-    /* Check if the command belongs to the slot range. */
-    struct redisCommand *cmd = lookupCommandBySds(argv[0]->ptr);
-    serverAssert(cmd);
-
     /* Ensure all arguments are converted to string encoding if necessary,
      * since getSlotFromCommand expects them to be string-encoded.
      * Generally the arguments are string-encoded, but we may rewrite
@@ -600,6 +596,11 @@ void asmFeedMigrationClient(robj **argv, int argc) {
             decrRefCount(old);
         }
     }
+
+    /* Check if the command belongs to the slot range. */
+    struct redisCommand *cmd = lookupCommand(argv, argc);
+    serverAssert(cmd);
+
     int slot = getSlotFromCommand(cmd, argv, argc);
 
     /* If the command does not have keys, skip it now.
@@ -2872,12 +2873,13 @@ void asmActiveTrimStart(void) {
     serverAssert(asmManager->active_trim_it == NULL);
     asmManager->active_trim_it = slotRangeArrayGetIterator(slots);
     asmManager->active_trim_started++;
-    asmManager->active_trim_keys_deleted = 0;
+    asmManager->active_trim_current_job_keys = 0;
+    asmManager->active_trim_current_job_trimmed = 0;
 
     /* Count the number of keys to trim */
     for (int i = 0; i < slots->num_ranges; i++)  {
         for (int slot = slots->ranges[i].start; slot <= slots->ranges[i].end; slot++)
-            asmManager->active_trim_keys_total += kvstoreDictSize(server.db[0].keys, slot);
+            asmManager->active_trim_current_job_keys += kvstoreDictSize(server.db[0].keys, slot);
     }        
 
     RedisModuleClusterAsmTrimInfoV1 fsi = {
@@ -2925,7 +2927,7 @@ void asmActiveTrimEnd(void) {
 
     sds str = slotRangeArrayToString(slots);
     serverLog(LL_NOTICE, "Active trim completed for slots: %s, %llu keys trimmed.",
-              str, asmManager->active_trim_keys_deleted);
+              str, asmManager->active_trim_current_job_trimmed);
     sdsfree(str);
     listDelNode(asmManager->active_trim_jobs, listFirst(asmManager->active_trim_jobs));
     asmManager->active_trim_done++;
@@ -2960,7 +2962,7 @@ void asmActiveTrimDeleteKey(redisDb *db, robj *keyobj) {
 
     dbDelete(db, keyobj);
     notifyKeyspaceEvent(NOTIFY_TRIMMED, "trimmed", keyobj, db->id);
-    asmManager->active_trim_keys_deleted++;
+    asmManager->active_trim_current_job_trimmed++;
 
     if (static_key) decrRefCount(keyobj);
 }

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -866,8 +866,8 @@ void clusterMigrationCommand(client *c) {
 
 /* Notify the state change to the module and the plugin. */
 void asmNotifyStateChange(asmTask *task, int state) {
-    RedisModuleClusterAsmMigrationInfo info = {
-            .version = REDISMODULE_CLUSTER_ASM_MIGRATIONINFO_VERSION,
+    RedisModuleClusterAsmInfo info = {
+            .version = REDISMODULE_CLUSTER_ASM_INFO_VERSION,
             .task_id = task->id,
             .slots = (RedisModuleSlotRangeArray *) task->slot_ranges
     };
@@ -1949,8 +1949,8 @@ static int slotSnapshotSaveKeyValuePair(rio *rdb, kvobj *o, int dbid) {
  * delivered just before the slot snapshot delivery starts. This function
  * triggers the event, collects the commands and writes them to the rio. */
 static int propagateModuleCommands(asmTask *task, rio *rdb) {
-    RedisModuleClusterAsmMigrationInfo info = {
-            .version = REDISMODULE_CLUSTER_ASM_MIGRATIONINFO_VERSION,
+    RedisModuleClusterAsmInfo info = {
+            .version = REDISMODULE_CLUSTER_ASM_INFO_VERSION,
             .task_id = task->id,
             .slots = (RedisModuleSlotRangeArray *) task->slot_ranges
     };

--- a/src/module.c
+++ b/src/module.c
@@ -11692,7 +11692,7 @@ static uint64_t moduleEventVersions[] = {
     -1, /* REDISMODULE_EVENT_EVENTLOOP */
     -1, /* REDISMODULE_EVENT_CONFIG */
     REDISMODULE_KEYINFO_VERSION, /* REDISMODULE_EVENT_KEY */
-    REDISMODULE_CLUSTER_ASM_MIGRATIONINFO_VERSION, /* REDISMODULE_EVENT_CLUSTER_ASM */
+    REDISMODULE_CLUSTER_ASM_INFO_VERSION, /* REDISMODULE_EVENT_CLUSTER_ASM */
     REDISMODULE_CLUSTER_ASM_TRIMINFO_VERSION, /* REDISMODULE_EVENT_CLUSTER_ASM_TRIM */
 };
 
@@ -11997,7 +11997,7 @@ static uint64_t moduleEventVersions[] = {
  *     * `REDISMODULE_SUBEVENT_CLUSTER_ASM_MIGRATE_COMPLETED`
  *     * `REDISMODULE_SUBEVENT_CLUSTER_ASM_MIGRATE_MODULE_PROPAGATE`
  *
- *     The data pointer can be casted to a RedisModuleClusterAsmMigrationInfo
+ *     The data pointer can be casted to a RedisModuleClusterAsmInfo
  *     structure with the following fields:
  *         char source_node_id[REDISMODULE_NODE_ID_LEN + 1];
  *         char destination_node_id[REDISMODULE_NODE_ID_LEN + 1];

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -860,9 +860,9 @@ typedef struct RedisModuleSlotRangeArray {
     RedisModuleSlotRange ranges[];
 } RedisModuleSlotRangeArray;
 
-#define REDISMODULE_CLUSTER_ASM_MIGRATIONINFO_VERSION 1
+#define REDISMODULE_CLUSTER_ASM_INFO_VERSION 1
 
-typedef struct RedisModuleClusterAsmMigrationInfo {
+typedef struct RedisModuleClusterAsmInfo {
     uint64_t version;       /* Not used since this structure is never passed
                                from the module to the core right now. Here
                                for future compatibility. */
@@ -870,9 +870,9 @@ typedef struct RedisModuleClusterAsmMigrationInfo {
     char destination_node_id[REDISMODULE_NODE_ID_LEN + 1];
     const char *task_id;
     RedisModuleSlotRangeArray *slots;
-} RedisModuleClusterAsmMigrationInfoV1;
+} RedisModuleClusterAsmInfoV1;
 
-#define RedisModuleClusterAsmMigrationInfo RedisModuleClusterAsmMigrationInfoV1
+#define RedisModuleClusterAsmInfo RedisModuleClusterAsmInfoV1
 
 #define REDISMODULE_CLUSTER_ASM_TRIMINFO_VERSION 1
 

--- a/src/server.c
+++ b/src/server.c
@@ -3495,14 +3495,7 @@ static void propagateNow(int dbid, robj **argv, int argc, int target) {
         feedAppendOnlyFile(dbid,argv,argc);
     if (target & PROPAGATE_REPL) {
         replicationFeedSlaves(server.slaves,dbid,argv,argc);
-
-        /* Normally, MULTI/EXEC transactions are used to replicate a command's
-         * effects in an atomic way to prevent partial state on the destination
-         * side. Though, it is unnecessary for ASM since keys aren't accessed on
-         * the destination until slot ownership transfer completes. Therefore,
-         * skip MULTI and EXEC commands. */
-        if (argc != 1 || (argv != &shared.multi && argv != &shared.exec))
-            asmFeedMigrationClient(argv, argc);
+        asmFeedMigrationClient(argv, argc);
     }
 }
 

--- a/tests/modules/atomicslotmigration.c
+++ b/tests/modules/atomicslotmigration.c
@@ -262,6 +262,17 @@ static int keyspaceNotificationTrimmedCallback(RedisModuleCtx *ctx, int type, co
     return REDISMODULE_OK;
 }
 
+/* ASM.PARENT SET key value  (just proxy to Redis SET) */
+static int asmParentSet(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 4) return RedisModule_WrongArity(ctx);
+    RedisModuleCallReply *reply = RedisModule_Call(ctx, "SET", "ss", argv[2], argv[3]);
+    if (!reply) return RedisModule_ReplyWithError(ctx, "ERR internal");
+    RedisModule_ReplyWithCallReply(ctx, reply);
+    RedisModule_FreeCallReply(reply);
+    RedisModule_ReplicateVerbatim(ctx);
+    return REDISMODULE_OK;
+}
+
 /* Clear both the cluster and trim event logs. */
 int clearEventLog(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     REDISMODULE_NOT_USED(argv);
@@ -353,6 +364,16 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
         return REDISMODULE_ERR;
 
     if (RedisModule_CreateCommand(ctx, "asm.lpush_replicate_crossslot_command", lpush_and_replicate_crossslot_command, "write", 0, 0, 0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx, "asm.parent", NULL, "", 0, 0, 0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    RedisModuleCommand *parent = RedisModule_GetCommand(ctx, "asm.parent");
+    if (!parent) return REDISMODULE_ERR;
+
+    /* Subcommand: ASM.PARENT SET (write) */
+    if (RedisModule_CreateSubcommand(parent, "set", asmParentSet, "write fast", 2, 2, 1) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
     if (RedisModule_SubscribeToServerEvent(ctx, RedisModuleEvent_ClusterAsm, clusterEventCallback) == REDISMODULE_ERR)

--- a/tests/modules/atomicslotmigration.c
+++ b/tests/modules/atomicslotmigration.c
@@ -113,7 +113,7 @@ int testClusterCanAccessKeysInSlot(RedisModuleCtx *ctx, RedisModuleString **argv
 
 /* Generate a string representation of the info struct and subevent.
    e.g. 'sub: cluster-asm-import-started, task_id: aeBd..., slots: 0-100,200-300' */
-const char *clusterMigrationInfoToString(RedisModuleClusterAsmMigrationInfo *info, uint64_t sub) {
+const char *clusterAsmInfoToString(RedisModuleClusterAsmInfo *info, uint64_t sub) {
     char buf[1024] = {0};
 
     if (sub == REDISMODULE_SUBEVENT_CLUSTER_ASM_IMPORT_STARTED)
@@ -168,7 +168,7 @@ const char *clusterTrimInfoToString(RedisModuleClusterAsmTrimInfo *info, uint64_
     return RedisModule_Strdup(buf);
 }
 
-static void testReplicatingOutsideSlotRange(RedisModuleCtx *ctx, RedisModuleClusterAsmMigrationInfo *info) {
+static void testReplicatingOutsideSlotRange(RedisModuleCtx *ctx, RedisModuleClusterAsmInfo *info) {
     int slot = 0;
     while (slot >= 0 && slot <= 16383) {
         if (!slotRangeArrayContains(info->slots, slot)) {
@@ -199,7 +199,7 @@ static void testReplicatingUnknownCommand(RedisModuleCtx *ctx) {
     RedisModule_Assert(errno == ENOENT);
 }
 
-static void testNonFatalScenarios(RedisModuleCtx *ctx, RedisModuleClusterAsmMigrationInfo *info) {
+static void testNonFatalScenarios(RedisModuleCtx *ctx, RedisModuleClusterAsmInfo *info) {
     testReplicatingOutsideSlotRange(ctx, info);
     testReplicatingCrossslotCommand(ctx);
     testReplicatingUnknownCommand(ctx);
@@ -210,7 +210,7 @@ void clusterEventCallback(RedisModuleCtx *ctx, RedisModuleEvent e, uint64_t sub,
     int ret;
 
     if (e.id == REDISMODULE_EVENT_CLUSTER_ASM) {
-        RedisModuleClusterAsmMigrationInfo *info = data;
+        RedisModuleClusterAsmInfo *info = data;
 
         if (sub == REDISMODULE_SUBEVENT_CLUSTER_ASM_MIGRATE_MODULE_PROPAGATE) {
             /* Test some non-fatal scenarios. */
@@ -228,7 +228,7 @@ void clusterEventCallback(RedisModuleCtx *ctx, RedisModuleEvent e, uint64_t sub,
         } else {
             /* Log the event. */
             if (numClusterEvents >= MAX_EVENTS) return;
-            clusterEventLog[numClusterEvents++] = clusterMigrationInfoToString(info, sub);
+            clusterEventLog[numClusterEvents++] = clusterAsmInfoToString(info, sub);
         }
     }
 }

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -1466,15 +1466,15 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         wait_for_condition 1000 10 {
             [CI 0 cluster_slot_migration_task_count] == 0 &&
             [CI 0 cluster_slot_migration_active_trim_jobs] == 0 &&
-            [CI 0 cluster_slot_migration_active_trim_keys_deleted] == 1500 &&
+            [CI 0 cluster_slot_migration_active_trim_current_job_trimmed] == 1500 &&
             [CI 3 cluster_slot_migration_active_trim_jobs] == 0 &&
-            [CI 3 cluster_slot_migration_active_trim_keys_deleted] == 1500
+            [CI 3 cluster_slot_migration_active_trim_current_job_trimmed] == 1500
         } else {
             fail "trim failed"
         }
 
-        assert_equal 1500 [CI 0 cluster_slot_migration_active_trim_keys_total]
-        assert_equal 1500 [CI 3 cluster_slot_migration_active_trim_keys_total]
+        assert_equal 1500 [CI 0 cluster_slot_migration_active_trim_current_job_keys]
+        assert_equal 1500 [CI 3 cluster_slot_migration_active_trim_current_job_keys]
 
         assert_equal 500 [R 0 dbsize]
         assert_equal 500 [R 3 dbsize]
@@ -1561,8 +1561,8 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         R 1 CLUSTER MIGRATION CANCEL ALL
         wait_for_asm_done
 
-        assert_morethan [CI 1 cluster_slot_migration_active_trim_keys_deleted] 0
-        assert_morethan [CI 4 cluster_slot_migration_active_trim_keys_deleted] 0
+        assert_morethan [CI 1 cluster_slot_migration_active_trim_current_job_keys] 0
+        assert_morethan [CI 4 cluster_slot_migration_active_trim_current_job_trimmed] 0
 
         assert_equal 1000 [R 0 dbsize]
         assert_equal 1000 [R 3 dbsize]
@@ -1721,9 +1721,9 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
 
         # Pause the server and verify no keys are trimmed
         R 0 client pause 100000 write ;# pause 100s
-        set prev [CI 0 cluster_slot_migration_active_trim_keys_deleted]
+        set prev [CI 0 cluster_slot_migration_active_trim_current_job_trimmed]
         after 1000 ; # wait some time to see if any keys are trimmed
-        set curr [CI 0 cluster_slot_migration_active_trim_keys_deleted]
+        set curr [CI 0 cluster_slot_migration_active_trim_current_job_trimmed]
         assert_equal $prev $curr
 
         R 0 client unpause
@@ -1847,7 +1847,6 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         R 1 flushall
 
         set prev_trim_done [CI 1 cluster_slot_migration_active_trim_done]
-        set prev_trim_keys_total [CI 1 cluster_slot_migration_active_trim_keys_total]
 
         R 1 debug populate 1000 [slot_prefix 0] 100
         R 1 debug populate 1000 [slot_prefix 1] 100
@@ -1860,8 +1859,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         R 1 exec
 
         wait_for_condition 1000 10 {
-            [CI 1 cluster_slot_migration_active_trim_done] == $prev_trim_done + 3 &&
-            [CI 1 cluster_slot_migration_active_trim_keys_total] == $prev_trim_keys_total + 3000
+            [CI 1 cluster_slot_migration_active_trim_done] == $prev_trim_done + 3
         } else {
             fail "active trim failed"
         }
@@ -2143,5 +2141,16 @@ start_cluster 3 3 [list tags {external:skip cluster modules} config_lines [list 
         wait_for_asm_done
         R 0 flushall
         R 1 flushall
+    }
+
+    test "Test subcommand propagation during slot migration" {
+        R 0 flushall
+        R 1 flushall
+        set task_id [setup_slot_migration_with_delay 0 1 0 100]
+
+        set key [slot_key 0 mykey]
+        R 0 asm.parent set $key "value" ;# execute a module subcommand
+        wait_for_asm_done
+        assert_equal "value" [R 1 GET $key]
     }
 }

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -103,11 +103,11 @@ proc wait_for_asm_done {} {
 
     for {set i 0} {$i < $total_instances} {incr i} {
         wait_for_condition 1000 10 {
-            [CI $i cluster_slot_migration_task_count] == 0 &&
-            [CI $i cluster_slot_migration_active_trim_jobs] == 0
+            [CI $i slot_migration_task_count] == 0 &&
+            [CI $i slot_migration_active_trim_jobs] == 0
         } else {
-            set migration_count [CI $i cluster_slot_migration_task_count]
-            set trim_count [CI $i cluster_slot_migration_active_trim_jobs]
+            set migration_count [CI $i slot_migration_task_count]
+            set trim_count [CI $i slot_migration_active_trim_jobs]
             fail "ASM tasks did not complete on instance $i: migration_tasks=$migration_count, trim_tasks=$trim_count"
         }
     }
@@ -1464,17 +1464,17 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         wait_for_asm_done
 
         wait_for_condition 1000 10 {
-            [CI 0 cluster_slot_migration_task_count] == 0 &&
-            [CI 0 cluster_slot_migration_active_trim_jobs] == 0 &&
-            [CI 0 cluster_slot_migration_active_trim_current_job_trimmed] == 1500 &&
-            [CI 3 cluster_slot_migration_active_trim_jobs] == 0 &&
-            [CI 3 cluster_slot_migration_active_trim_current_job_trimmed] == 1500
+            [CI 0 slot_migration_task_count] == 0 &&
+            [CI 0 slot_migration_active_trim_jobs] == 0 &&
+            [CI 0 slot_migration_active_trim_current_job_trimmed] == 1500 &&
+            [CI 3 slot_migration_active_trim_jobs] == 0 &&
+            [CI 3 slot_migration_active_trim_current_job_trimmed] == 1500
         } else {
             fail "trim failed"
         }
 
-        assert_equal 1500 [CI 0 cluster_slot_migration_active_trim_current_job_keys]
-        assert_equal 1500 [CI 3 cluster_slot_migration_active_trim_current_job_keys]
+        assert_equal 1500 [CI 0 slot_migration_active_trim_current_job_keys]
+        assert_equal 1500 [CI 3 slot_migration_active_trim_current_job_keys]
 
         assert_equal 500 [R 0 dbsize]
         assert_equal 500 [R 3 dbsize]
@@ -1507,9 +1507,9 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         # Migrate 1500 keys
         R 1 CLUSTER MIGRATION IMPORT 0 1
         wait_for_condition 1000 10 {
-            [CI 0 cluster_slot_migration_task_count] == 0 &&
-            [CI 0 cluster_slot_migration_active_trim_jobs] == 1 &&
-            [CI 3 cluster_slot_migration_active_trim_jobs] == 1
+            [CI 0 slot_migration_task_count] == 0 &&
+            [CI 0 slot_migration_active_trim_jobs] == 1 &&
+            [CI 3 slot_migration_active_trim_jobs] == 1
         } else {
             fail "migrate failed"
         }
@@ -1517,9 +1517,9 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         # Migrate another slot and verify there are two trim tasks on the source
         R 1 CLUSTER MIGRATION IMPORT 3 3
         wait_for_condition 1000 10 {
-            [CI 0 cluster_slot_migration_task_count] == 0 &&
-            [CI 0 cluster_slot_migration_active_trim_jobs] == 2 &&
-            [CI 3 cluster_slot_migration_active_trim_jobs] == 2
+            [CI 0 slot_migration_task_count] == 0 &&
+            [CI 0 slot_migration_active_trim_jobs] == 2 &&
+            [CI 3 slot_migration_active_trim_jobs] == 2
         } else {
             fail "migrate failed"
         }
@@ -1561,8 +1561,8 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         R 1 CLUSTER MIGRATION CANCEL ALL
         wait_for_asm_done
 
-        assert_morethan [CI 1 cluster_slot_migration_active_trim_current_job_keys] 0
-        assert_morethan [CI 4 cluster_slot_migration_active_trim_current_job_trimmed] 0
+        assert_morethan [CI 1 slot_migration_active_trim_current_job_keys] 0
+        assert_morethan [CI 4 slot_migration_active_trim_current_job_trimmed] 0
 
         assert_equal 1000 [R 0 dbsize]
         assert_equal 1000 [R 3 dbsize]
@@ -1587,8 +1587,8 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         # Migrate 1000 keys
         R 1 CLUSTER MIGRATION IMPORT 0 1
         wait_for_condition 1000 10 {
-            [CI 0 cluster_slot_migration_task_count] == 0 &&
-            [CI 0 cluster_slot_migration_active_trim_jobs] == 1
+            [CI 0 slot_migration_task_count] == 0 &&
+            [CI 0 slot_migration_active_trim_jobs] == 1
         } else {
             fail "migrate failed"
         }
@@ -1623,12 +1623,12 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         # Start migration and wait until trim is in progress
         R 1 CLUSTER MIGRATION IMPORT 0 1
         wait_for_condition 1000 10 {
-            [CI 0 cluster_slot_migration_task_count] == 0 &&
-            [CI 0 cluster_slot_migration_active_trim_jobs] == 1 &&
+            [CI 0 slot_migration_task_count] == 0 &&
+            [CI 0 slot_migration_active_trim_jobs] == 1 &&
             [S 0 rdb_bgsave_in_progress] == 0
         } else {
-            puts "[CI 0 cluster_slot_migration_task_count]"
-            puts "[CI 0 cluster_slot_migration_active_trim_jobs]"
+            puts "[CI 0 slot_migration_task_count]"
+            puts "[CI 0 slot_migration_active_trim_jobs]"
             fail "trim failed"
         }
 
@@ -1666,11 +1666,11 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
 
         R 1 CLUSTER MIGRATION IMPORT 0 1
         wait_for_condition 1000 10 {
-            [CI 0 cluster_slot_migration_task_count] == 0 &&
-            [CI 0 cluster_slot_migration_active_trim_jobs] == 1
+            [CI 0 slot_migration_task_count] == 0 &&
+            [CI 0 slot_migration_active_trim_jobs] == 1
         } else {
-            puts "[CI 0 cluster_slot_migration_task_count]"
-            puts "[CI 0 cluster_slot_migration_active_trim_jobs]"
+            puts "[CI 0 slot_migration_task_count]"
+            puts "[CI 0 slot_migration_active_trim_jobs]"
             fail "trim failed"
         }
 
@@ -1711,19 +1711,19 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
 
         R 1 CLUSTER MIGRATION IMPORT 0 100
         wait_for_condition 1000 10 {
-            [CI 0 cluster_slot_migration_task_count] == 0 &&
-            [CI 0 cluster_slot_migration_active_trim_jobs] == 1
+            [CI 0 slot_migration_task_count] == 0 &&
+            [CI 0 slot_migration_active_trim_jobs] == 1
         } else {
-            puts "[CI 0 cluster_slot_migration_task_count]"
-            puts "[CI 0 cluster_slot_migration_active_trim_jobs]"
+            puts "[CI 0 slot_migration_task_count]"
+            puts "[CI 0 slot_migration_active_trim_jobs]"
             fail "trim failed"
         }
 
         # Pause the server and verify no keys are trimmed
         R 0 client pause 100000 write ;# pause 100s
-        set prev [CI 0 cluster_slot_migration_active_trim_current_job_trimmed]
+        set prev [CI 0 slot_migration_active_trim_current_job_trimmed]
         after 1000 ; # wait some time to see if any keys are trimmed
-        set curr [CI 0 cluster_slot_migration_active_trim_current_job_trimmed]
+        set curr [CI 0 slot_migration_active_trim_current_job_trimmed]
         assert_equal $prev $curr
 
         R 0 client unpause
@@ -1748,37 +1748,37 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
 
             R 1 CLUSTER MIGRATION IMPORT 0 100
             wait_for_condition 1000 10 {
-                [CI 0 cluster_slot_migration_task_count] == 0 &&
-                [CI 0 cluster_slot_migration_active_trim_jobs] == 0 &&
-                [CI 3 cluster_slot_migration_active_trim_jobs] == 1
+                [CI 0 slot_migration_task_count] == 0 &&
+                [CI 0 slot_migration_active_trim_jobs] == 0 &&
+                [CI 3 slot_migration_active_trim_jobs] == 1
             } else {
-                puts "[CI 0 cluster_slot_migration_task_count]"
-                puts "[CI 0 cluster_slot_migration_active_trim_jobs]"
-                puts "[CI 3 cluster_slot_migration_active_trim_jobs]"
+                puts "[CI 0 slot_migration_task_count]"
+                puts "[CI 0 slot_migration_active_trim_jobs]"
+                puts "[CI 3 slot_migration_active_trim_jobs]"
                 fail "trim failed"
             }
 
             R 0 CLUSTER MIGRATION IMPORT 0 100
             wait_for_condition 1000 10 {
-                [CI 0 cluster_slot_migration_task_count] == 0 &&
-                [CI 0 cluster_slot_migration_active_trim_jobs] == 0 &&
-                [CI 3 cluster_slot_migration_active_trim_jobs] == 1
+                [CI 0 slot_migration_task_count] == 0 &&
+                [CI 0 slot_migration_active_trim_jobs] == 0 &&
+                [CI 3 slot_migration_active_trim_jobs] == 1
             } else {
                 fail "trim failed"
             }
 
-            set prev_cancelled [CI 3 cluster_slot_migration_active_trim_cancelled]
+            set prev_cancelled [CI 3 slot_migration_active_trim_cancelled]
             R 0 config set client-output-buffer-limit "replica 1024 0 0"
 
             # Trigger a fullsync
             populate_slot 1 -idx 0 -size 2000000 -slot 2
 
             wait_for_condition 1000 10 {
-                [CI 3 cluster_slot_migration_active_trim_jobs] == 0 &&
-                [CI 3 cluster_slot_migration_active_trim_cancelled] == $prev_cancelled + 1
+                [CI 3 slot_migration_active_trim_jobs] == 0 &&
+                [CI 3 slot_migration_active_trim_cancelled] == $prev_cancelled + 1
             } else {
-                puts "[CI 3 cluster_slot_migration_active_trim_jobs]"
-                puts "[CI 3 cluster_slot_migration_active_trim_cancelled]"
+                puts "[CI 3 slot_migration_active_trim_jobs]"
+                puts "[CI 3 slot_migration_active_trim_cancelled]"
                 fail "trim failed"
             }
 
@@ -1802,22 +1802,22 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
        # Wait until active trim is in progress on replica
        R 1 CLUSTER MIGRATION IMPORT 0 100
        wait_for_condition 1000 10 {
-           [CI 0 cluster_slot_migration_task_count] == 0 &&
-           [CI 0 cluster_slot_migration_active_trim_jobs] == 0 &&
-           [CI 3 cluster_slot_migration_active_trim_jobs] == 1
+           [CI 0 slot_migration_task_count] == 0 &&
+           [CI 0 slot_migration_active_trim_jobs] == 0 &&
+           [CI 3 slot_migration_active_trim_jobs] == 1
        } else {
-           puts "[CI 0 cluster_slot_migration_task_count]"
-           puts "[CI 0 cluster_slot_migration_active_trim_jobs]"
-           puts "[CI 3 cluster_slot_migration_active_trim_jobs]"
+           puts "[CI 0 slot_migration_task_count]"
+           puts "[CI 0 slot_migration_active_trim_jobs]"
+           puts "[CI 3 slot_migration_active_trim_jobs]"
            fail "trim failed"
        }
 
        # Get slots back
        R 0 CLUSTER MIGRATION IMPORT 0 100
        wait_for_condition 1000 20 {
-           [CI 0 cluster_slot_migration_task_count] == 1 &&
-           [CI 0 cluster_slot_migration_active_trim_jobs] == 0 &&
-           [CI 3 cluster_slot_migration_active_trim_jobs] == 1
+           [CI 0 slot_migration_task_count] == 1 &&
+           [CI 0 slot_migration_active_trim_jobs] == 0 &&
+           [CI 3 slot_migration_active_trim_jobs] == 1
        } else {
            fail "trim failed"
        }
@@ -1846,7 +1846,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         R 1 debug asm-trim-method active 0
         R 1 flushall
 
-        set prev_trim_done [CI 1 cluster_slot_migration_active_trim_done]
+        set prev_trim_done [CI 1 slot_migration_active_trim_done]
 
         R 1 debug populate 1000 [slot_prefix 0] 100
         R 1 debug populate 1000 [slot_prefix 1] 100
@@ -1859,7 +1859,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         R 1 exec
 
         wait_for_condition 1000 10 {
-            [CI 1 cluster_slot_migration_active_trim_done] == $prev_trim_done + 3
+            [CI 1 slot_migration_active_trim_done] == $prev_trim_done + 3
         } else {
             fail "active trim failed"
         }
@@ -1959,9 +1959,9 @@ start_cluster 3 3 [list tags {external:skip cluster modules} config_lines [list 
         assert_equal 0 [R 4 asm.cluster_can_access_keys_in_slot 100]
 
         wait_for_condition 1000 10 {
-            [CI 0 cluster_slot_migration_task_count] == 0 &&
-            [CI 0 cluster_slot_migration_active_trim_jobs] == 1 &&
-            [CI 3 cluster_slot_migration_active_trim_jobs] == 1
+            [CI 0 slot_migration_task_count] == 0 &&
+            [CI 0 slot_migration_active_trim_jobs] == 1 &&
+            [CI 3 slot_migration_active_trim_jobs] == 1
         } else {
             fail "migrate failed"
         }

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -2154,7 +2154,7 @@ start_cluster 3 3 [list tags {external:skip cluster modules} config_lines [list 
         assert_equal "value" [R 1 GET $key]
 
         # cleanup
-        R 0 cluster migration import 0 1
+        R 0 cluster migration import 0 100
         wait_for_asm_done
     }
 

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -2178,7 +2178,7 @@ start_cluster 3 3 [list tags {external:skip cluster modules} config_lines [list 
     }
 }
 
-start_server {tags "cluster"} {
+start_server {tags "cluster external:skip"} {
     test "Test RM_ClusterGetLocalSlotRanges without cluster" {
         r module load $testmodule
         assert_equal [r asm.cluster_get_local_slot_ranges] {{0 16383}}


### PR DESCRIPTION
- Rename trim stats and initialize on each trim job
- Rename `RedisModuleClusterAsmMigrationInfo` -> `RedisModuleClusterAsmInfo`
- Do not use `cluster_` prefix for ASM related fields in `CLUSTER INFO`.
- Fix subcommand propagation and add a test
- Avoid named filter for MULTI and EXEC.