### PR TITLE
renaming

### DIFF
--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -43,7 +43,7 @@ typedef struct asmTask {
     long long retry_count;              /* Number of retries for this task */
     mstime_t create_time;               /* Task creation time */
     mstime_t start_time;                /* Task start time */
-    mstime_t done_time;                 /* Task completion time */
+    mstime_t end_time;                  /* Task end time */
     mstime_t paused_time;               /* The time when the slot writes were paused */
     mstime_t dest_slots_snapshot_time;  /* The time when the destination starts applying the slot snapshot */
     mstime_t dest_accum_applied_time;   /* The time when the destination finishes applying the accumulated buffer */
@@ -53,12 +53,11 @@ typedef struct asmTask {
 
 struct asmManager {
     list *tasks;                        /* List of asmTask to be processed */
-    list *done_tasks;                   /* List of completed asmTask */
+    list *archived_tasks;               /* List of archived asmTask */
     list *pending_trim_jobs;            /* List of pending trim jobs (due to write pause) */
     list *active_trim_jobs;             /* List of active trim jobs */
     slotRangeArrayIter *active_trim_it; /* Iterator of the current active trim job */
     size_t sync_buffer_peak;            /* Peak size of sync buffer */
-    long long total_done_tasks;         /* Total number of completed tasks */
     asmTask *master_task;               /* The task that is currently active on the master */
 
     /* Fail point injection for debugging */
@@ -69,7 +68,7 @@ struct asmManager {
 
     /* Active trim stats */
     unsigned long long active_trim_started;             /* Number of times active trim was started */
-    unsigned long long active_trim_done;                /* Number of times active trim was completed */
+    unsigned long long active_trim_completed;           /* Number of times active trim was completed */
     unsigned long long active_trim_cancelled;           /* Number of times active trim was cancelled */
     unsigned long long active_trim_current_job_keys;    /* Total number of keys to trim in the current job */
     unsigned long long active_trim_current_job_trimmed; /* Number of keys trimmed in the current job */
@@ -82,7 +81,7 @@ enum asmState {
     ASM_AUTH_REPLY,
     ASM_CANCELED,
     ASM_FAILED,
-    ASM_DONE,
+    ASM_COMPLETED,
 
     /* Import state */
     ASM_SEND_HANDSHAKE,
@@ -103,7 +102,7 @@ enum asmState {
     ASM_SEND_STREAM,
     ASM_HANDOFF_PREP,
     ASM_HANDOFF,
-    ASM_STREAM_DONE,
+    ASM_STREAM_EOF,
 
     /* RDB channel state */
     ASM_RDBCHANNEL_REQUEST,
@@ -147,10 +146,9 @@ void asmNotifyStateChange(asmTask *task, int event);
 void clusterAsmInit(void) {
     asmManager = zcalloc(sizeof(*asmManager));
     asmManager->tasks = listCreate();
-    asmManager->done_tasks = listCreate();
+    asmManager->archived_tasks = listCreate();
     asmManager->pending_trim_jobs = listCreate();
     asmManager->sync_buffer_peak = 0;
-    asmManager->total_done_tasks = 0;
     asmManager->master_task = NULL;
     asmManager->debug_failed_channel = 0;
     asmManager->debug_failed_state = 0;
@@ -158,7 +156,7 @@ void clusterAsmInit(void) {
     asmManager->debug_active_trim_delay = 0;
     asmManager->active_trim_jobs = listCreate();
     asmManager->active_trim_started = 0;
-    asmManager->active_trim_done = 0;
+    asmManager->active_trim_completed = 0;
     asmManager->active_trim_cancelled = 0;
     listSetFreeMethod(asmManager->active_trim_jobs, (void (*)(void*))slotRangeArrayFree);
 }
@@ -170,7 +168,7 @@ char *asmTaskStateToString(int state) {
         case ASM_AUTH_REPLY: return "auth-reply";
         case ASM_CANCELED: return "canceled";
         case ASM_FAILED: return "failed";
-        case ASM_DONE: return "done";
+        case ASM_COMPLETED: return "completed";
 
         /* Import state */
         case ASM_SEND_HANDSHAKE: return "send-handshake";
@@ -191,7 +189,7 @@ char *asmTaskStateToString(int state) {
         case ASM_SEND_STREAM: return "send-stream";
         case ASM_HANDOFF_PREP: return "handoff-prep";
         case ASM_HANDOFF: return "handoff";
-        case ASM_STREAM_DONE: return "stream-done";
+        case ASM_STREAM_EOF: return "stream-eof";
 
         /* RDB channel state */
         case ASM_RDBCHANNEL_REQUEST: return "rdbchannel-request";
@@ -303,20 +301,18 @@ sds asmCatInfoString(sds info) {
 
     return sdscatprintf(info ? info : sdsempty(),
                         "slot_migration_active_tasks:%d\r\n"
-                        "slot_migration_total_done_tasks:%lld\r\n"
                         "slot_migration_sync_buffer_peak:%zu\r\n"
                         "slot_migration_active_trim_jobs:%lu\r\n"
                         "slot_migration_active_trim_started:%llu\r\n"
-                        "slot_migration_active_trim_done:%llu\r\n"
+                        "slot_migration_active_trim_completed:%llu\r\n"
                         "slot_migration_active_trim_cancelled:%llu\r\n"
                         "slot_migration_active_trim_current_job_keys:%llu\r\n"
                         "slot_migration_active_trim_current_job_trimmed:%llu\r\n",
                         active_tasks,
-                        asmManager->total_done_tasks,
                         asmGetPeakSyncBufferSize(),
                         listLength(asmManager->active_trim_jobs),
                         asmManager->active_trim_started,
-                        asmManager->active_trim_done,
+                        asmManager->active_trim_completed,
                         asmManager->active_trim_cancelled,
                         asmManager->active_trim_current_job_keys,
                         asmManager->active_trim_current_job_trimmed);
@@ -350,7 +346,7 @@ asmTask *asmTaskCreate(const char *task_id) {
     task->retry_count = 0;
     task->create_time = server.mstime;
     task->start_time = -1;
-    task->done_time = -1;
+    task->end_time = -1;
     if (task_id) {
         task->id = sdsnew(task_id);
     } else {
@@ -372,11 +368,11 @@ void asmTaskFree(asmTask *task) {
 /* Convert the task state to the corresponding event. */
 int asmTaskStateToEvent(asmTask *task) {
     if (task->operation == ASM_IMPORT) {
-        if (task->state == ASM_DONE) return ASM_EVENT_IMPORT_COMPLETED;
+        if (task->state == ASM_COMPLETED) return ASM_EVENT_IMPORT_COMPLETED;
         else if (task->state == ASM_FAILED) return ASM_EVENT_IMPORT_FAILED;
         else return ASM_EVENT_IMPORT_STARTED;
     } else {
-        if (task->state == ASM_DONE) return ASM_EVENT_MIGRATE_COMPLETED;
+        if (task->state == ASM_COMPLETED) return ASM_EVENT_MIGRATE_COMPLETED;
         else if (task->state == ASM_FAILED) return ASM_EVENT_MIGRATE_FAILED;
         else return ASM_EVENT_MIGRATE_STARTED;
     }
@@ -509,7 +505,7 @@ sds asmDumpActiveImportTask(void) {
     if (clusterNodeIsSlave(getMyClusterNode()) &&
         asmManager->master_task &&
         asmManager->master_task->state != ASM_FAILED &&
-        asmManager->master_task->state != ASM_DONE)
+        asmManager->master_task->state != ASM_COMPLETED)
     {
         return asmTaskSerialize(asmManager->master_task);
     }
@@ -519,7 +515,7 @@ sds asmDumpActiveImportTask(void) {
     asmTask *task = listNodeValue(listFirst(asmManager->tasks));
     if (task->operation == ASM_MIGRATE) return NULL;
     if (task->state == ASM_NONE || task->state == ASM_FAILED ||
-        task->state == ASM_DONE) return NULL;
+        task->state == ASM_COMPLETED) return NULL;
 
     return asmTaskSerialize(task);
 }
@@ -938,11 +934,11 @@ static void replyTaskStatus(client *c, asmTask *task) {
     addReplyBulkLongLong(c, task->create_time);
     addReplyBulkCString(c, "start_time");
     addReplyBulkLongLong(c, task->start_time);
-    addReplyBulkCString(c, "done_time");
-    addReplyBulkLongLong(c, task->done_time);
+    addReplyBulkCString(c, "end_time");
+    addReplyBulkLongLong(c, task->end_time);
 
-    if (task->operation == ASM_MIGRATE && task->state == ASM_DONE)
-        p = task->done_time - task->paused_time;
+    if (task->operation == ASM_MIGRATE && task->state == ASM_COMPLETED)
+        p = task->end_time - task->paused_time;
     addReplyBulkCString(c, "write_pause_ms");
     addReplyBulkLongLong(c, p);
 }
@@ -965,7 +961,7 @@ static void clusterMigrationCommandStatus(client *c) {
         }
         sds id = c->argv[4]->ptr;
         asmTask *task = asmLookupTaskAt(asmManager->tasks, id);
-        if (!task) task = asmLookupTaskAt(asmManager->done_tasks, id);
+        if (!task) task = asmLookupTaskAt(asmManager->archived_tasks, id);
         if (!task) {
             addReplyArrayLen(c, 0);
             return;
@@ -979,12 +975,12 @@ static void clusterMigrationCommandStatus(client *c) {
             return;
         }
         addReplyArrayLen(c, listLength(asmManager->tasks) +
-                            listLength(asmManager->done_tasks));
+                            listLength(asmManager->archived_tasks));
         listRewind(asmManager->tasks, &li);
         while ((ln = listNext(&li)) != NULL)
             replyTaskStatus(c, listNodeValue(ln));
 
-        listRewind(asmManager->done_tasks, &li);
+        listRewind(asmManager->archived_tasks, &li);
         while ((ln = listNext(&li)) != NULL)
             replyTaskStatus(c, listNodeValue(ln));
     } else {
@@ -1144,17 +1140,14 @@ void asmTaskSetFailed(asmTask *task, const char *fmt, ...) {
         asmMigrateSetFailed(task);
 }
 
-/* The task is done or canceled and won't be retried. Update stats and
- * move it to the completed list. */
-void asmTaskComplete(asmTask *task) {
+/* The task is completed or canceled. Update stats and move it to
+ * the archived list. */
+void asmTaskFinalize(asmTask *task) {
     listNode *ln = listFirst(asmManager->tasks);
     serverAssert(ln->value == task);
 
-    /* Should never access it */
-    task->source_node = NULL;
-
-    task->done_time = server.mstime;
-    asmManager->total_done_tasks++;
+    task->source_node = NULL; /* Should never access it */
+    task->end_time = server.mstime;
 
     if (task->operation == ASM_IMPORT) {
         asmManager->sync_buffer_peak = max(asmManager->sync_buffer_peak,
@@ -1162,9 +1155,9 @@ void asmTaskComplete(asmTask *task) {
         replDataBufClear(&task->sync_buffer); /* Not used, so save memory */
     }
 
-    /* Move the task to the completed list */
+    /* Move the task to the archived list */
     listUnlinkNode(asmManager->tasks, ln);
-    listLinkNodeHead(asmManager->done_tasks, ln);
+    listLinkNodeHead(asmManager->archived_tasks, ln);
 }
 
 static void asmTaskCancel(asmTask *task, const char *reason) {
@@ -1172,7 +1165,7 @@ static void asmTaskCancel(asmTask *task, const char *reason) {
 
     asmTaskSetFailed(task, "Cancelled due to %s", reason);
     task->state = ASM_CANCELED;
-    asmTaskComplete(task);
+    asmTaskFinalize(task);
 }
 
 void asmImportTakeover(asmTask *task) {
@@ -1219,7 +1212,7 @@ void asmCallbackOnFreeClient(client *c) {
     if (c == task->rdb_channel_client) {
         /* TODO: Detect whether the bgsave is completed successfully and
          * update the state properly. */
-        task->rdb_channel_state = ASM_DONE;
+        task->rdb_channel_state = ASM_COMPLETED;
         /* We may not have detected whether the child process has exited yet,
          * so we can't determine whether the client has completed the slots
          * snapshot transfer. If the RDB channel is interrupted unexpectedly,
@@ -1602,7 +1595,7 @@ void asmSlotSnapshotSucceed(struct asmTask *task) {
     task->main_channel_client->lastinteraction = server.unixtime;
 
     task->state = ASM_SEND_STREAM;
-    task->rdb_channel_state = ASM_DONE;
+    task->rdb_channel_state = ASM_COMPLETED;
 }
 
 /* Called when the RDB channel fails to send the snapshot. */
@@ -1638,7 +1631,7 @@ void clusterSyncSlotsSnapshotEOF(client *c) {
 
     /* Clear the RDB channel connection */
     task->rdb_channel_conn = NULL;
-    task->rdb_channel_state = ASM_DONE;
+    task->rdb_channel_state = ASM_COMPLETED;
     serverLog(LL_NOTICE, "RDB channel snapshot transfer completed for the import task.");
 
     /* Free the RDB channel connection. */
@@ -1669,7 +1662,7 @@ void clusterSyncSlotsStreamEOF(client *c) {
 
     if (task->state == ASM_STREAMING_BUF) {
         /* We are still streaming the buffer to DB, mark the EOF received, and we
-         * can takeover after streaming is done. Since we may release the context
+         * can takeover after streaming is EOF. Since we may release the context
          * in asmImportTakeover, this breaks the context for streaming buffer. */
         task->stream_eof_during_streaming = 1;
         serverLog(LL_NOTICE, "CLUSTER SYNCSLOTS STREAM-EOF received during streaming buffer");
@@ -2277,7 +2270,7 @@ static void asmReadSyncBufferErrorHandler(connection *conn) {
 
 /* Read data from connection into sync buffer. */
 static void asmSyncBufferReadFromConn(connection *conn) {
-    /* The task may be canceled (move to done list) or failed during streaming buffer. */
+    /* The task may be canceled (move to finished list) or failed during streaming buffer. */
     if (listLength(asmManager->tasks) == 0) return;
     asmTask *task = listNodeValue(listFirst(asmManager->tasks));
     if (task->state != ASM_ACCUMULATE_BUF && task->state != ASM_STREAMING_BUF) return;
@@ -2366,7 +2359,7 @@ void asmSyncBufferStreamToDb(asmTask *task) {
 
     /* Start streaming the buffer to the DB. This task may fail due to network
      * errors or cancellations. We never release the task immediately; instead,
-     * it may be moved to the 'done' list. The actual free happens in serverCron,
+     * it may be moved to the finished list. The actual free happens in serverCron,
      * which ensures there is no use-after-free issue. */
     int ret = replDataBufStreamToDb(&task->sync_buffer, &ctx);
 
@@ -2433,13 +2426,13 @@ void asmSendStreamEofIfDrained(asmTask *task) {
         /* There may be a delay to handle the disconnection of RDB channel,
          * so we clear the task and client references here. */
         if (task->rdb_channel_client != NULL) {
-            task->rdb_channel_state = ASM_DONE;
+            task->rdb_channel_state = ASM_COMPLETED;
             task->rdb_channel_client->task = NULL;
             freeClientAsync(task->rdb_channel_client);
             task->rdb_channel_client = NULL;
         }
 
-        task->state = ASM_STREAM_DONE;
+        task->state = ASM_STREAM_EOF;
     }
 }
 
@@ -2469,8 +2462,8 @@ void asmBeforeSleep(void) {
                 return;
             }
             asmSendStreamEofIfDrained(task);
-        } else if (task->state == ASM_STREAM_DONE) {
-            /* In state ASM_STREAM_DONE (server is still paused), we are waiting
+        } else if (task->state == ASM_STREAM_EOF) {
+            /* In state ASM_STREAM_EOF (server is still paused), we are waiting
              * for the destination node to broadcast the slot ownership change.
              * But maybe the destination node is failed or network is not available,
              * the source node may be paused forever. So we fail the task if it
@@ -2550,11 +2543,11 @@ void asmCron(void) {
         }
     }
 
-    /* Trim the done tasks list if it grows too large */
-    while (listLength(asmManager->done_tasks) > (unsigned long)server.asm_max_done_tasks) {
-        asmTask *oldest = listNodeValue(listLast(asmManager->done_tasks));
+    /* Trim the archived tasks list if it grows too large */
+    while (listLength(asmManager->archived_tasks) > (unsigned long)server.asm_max_archived_tasks) {
+        asmTask *oldest = listNodeValue(listLast(asmManager->archived_tasks));
         asmTaskFree(oldest);
-        listDelNode(asmManager->done_tasks, listLast(asmManager->done_tasks));
+        listDelNode(asmManager->archived_tasks, listLast(asmManager->archived_tasks));
     }
 }
 
@@ -2706,7 +2699,7 @@ int asmNotifyConfigUpdated(asmTask *task, sds *err) {
 
     if (task->operation == ASM_IMPORT && task->state == ASM_TAKEOVER) {
         event = ASM_EVENT_IMPORT_COMPLETED;
-    } else if (task->operation == ASM_MIGRATE && task->state == ASM_STREAM_DONE) {
+    } else if (task->operation == ASM_MIGRATE && task->state == ASM_STREAM_EOF) {
         event = ASM_EVENT_MIGRATE_COMPLETED;
     } else {
         *err = sdscatprintf(sdsempty(),
@@ -2719,12 +2712,12 @@ int asmNotifyConfigUpdated(asmTask *task, sds *err) {
     /* Clear error message if successful. */
     sdsfree(task->error);
     task->error = sdsempty();
-    task->state = ASM_DONE;
+    task->state = ASM_COMPLETED;
 
     asmNotifyStateChange(task, event);
-    asmTaskComplete(task);
+    asmTaskFinalize(task);
 
-    /* Trim the slots after the migrate task is done. */
+    /* Trim the slots after the migrate task is completed. */
     if (event == ASM_EVENT_MIGRATE_COMPLETED)
         asmTrimJobSchedule(task->slot_ranges);
 
@@ -2946,7 +2939,7 @@ void asmFinalizeMasterTask(void) {
     sdsfree(slot_ranges_str);
 
     /* Check if there is an ASM task that master did not finish. */
-    if (task->state != ASM_DONE && task->state != ASM_FAILED) {
+    if (task->state != ASM_COMPLETED && task->state != ASM_FAILED) {
         /* Mark the task as failed and notify the replicas. */
         task->state = ASM_FAILED;
         asmNotifyStateChange(task, ASM_EVENT_IMPORT_FAILED);
@@ -2969,7 +2962,7 @@ int asmReplicaHandleMasterTask(sds task_info) {
      * should check the slot ownership to decide to raise completed or failed event. */
     if (!task_info || sdslen(task_info) == 0) {
         asmTask *task = asmManager->master_task;
-        if (task && task->state != ASM_DONE && task->state != ASM_FAILED) {
+        if (task && task->state != ASM_COMPLETED && task->state != ASM_FAILED) {
             /* Check if the slots are owned by the master. */
             int owned_by_master = 1;
             for (int i = 0; i < task->slot_ranges->num_ranges; i++) {
@@ -2983,7 +2976,7 @@ int asmReplicaHandleMasterTask(sds task_info) {
                 }
             }
             if (owned_by_master) {
-                task->state = ASM_DONE;
+                task->state = ASM_COMPLETED;
                 asmNotifyStateChange(task, ASM_EVENT_IMPORT_COMPLETED);
             } else {
                 task->state = ASM_FAILED;
@@ -3011,8 +3004,8 @@ int asmReplicaHandleMasterTask(sds task_info) {
         }
         asmTaskFree(asmManager->master_task);
     } else {
-        /* Ignore done or failed task when there is no active master task. */
-        if (task->state != ASM_FAILED && task->state != ASM_DONE)
+        /* Ignore completed or failed task when there is no active master task. */
+        if (task->state != ASM_FAILED && task->state != ASM_COMPLETED)
             notify_event = 1;
     }
 
@@ -3031,7 +3024,7 @@ void asmUnblockMasterAfterTrim(void) {
         server.master->bstate.btype == BLOCKED_POSTPONE_TRIM)
     {
         unblockClient(server.master, 1);
-        serverLog(LL_NOTICE, "Unblocking master client after active trim is done");
+        serverLog(LL_NOTICE, "Unblocking master client after active trim is completed");
     }
 }
 
@@ -3062,7 +3055,7 @@ void asmCancelTrimJobs(void) {
     listEmpty(asmManager->active_trim_jobs);
 }
 
-/* It's used to trim slots after the migration is done or import is failed.
+/* It's used to trim slots after the migration is completed or import is failed.
  * TRIMSLOTS RANGES <numranges> <start-slot> <end-slot> ... */
 void trimslotsCommand(client *c) {
     long numranges = 0;
@@ -3191,7 +3184,7 @@ void asmActiveTrimEnd(void) {
               str, asmManager->active_trim_current_job_trimmed);
     sdsfree(str);
     listDelNode(asmManager->active_trim_jobs, listFirst(asmManager->active_trim_jobs));
-    asmManager->active_trim_done++;
+    asmManager->active_trim_completed++;
 }
 
 /* Check if the slot range array overlaps with any trim job. */

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -1974,11 +1974,11 @@ void clusterSyncSlotsCommand(client *c) {
             /* Pause write if needed */
             if (task->state == ASM_SEND_BULK_AND_STREAM || task->state == ASM_SEND_STREAM) {
                 /* Pause writes on the main channel if the lag is less than the threshold. */
-                if (task->dest_offset + server.asm_handoff_max_lag_size >= task->source_offset) {
+                if (task->dest_offset + server.asm_handoff_max_lag_bytes >= task->source_offset) {
                     serverLog(LL_NOTICE, "The applied offset lag %lld is less than the threshold %lld, "
                                          "pausing writes for slot handoff",
                                          task->source_offset - task->dest_offset,
-                                         server.asm_handoff_max_lag_size);
+                                         server.asm_handoff_max_lag_bytes);
                     task->state = ASM_HANDOFF_PREP;
                     clusterAsmOnEvent(task->id, ASM_EVENT_HANDOFF_PREP, task->slot_ranges);
                 }

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -916,14 +916,14 @@ static void replyTaskStatus(client *c, asmTask *task) {
     addReplyMapLen(c, 12);
     addReplyBulkCString(c, "id");
     addReplyBulkCString(c, task->id);
-    addReplyBulkCString(c, "slots_range");
+    addReplyBulkCString(c, "slot_ranges");
     addReplyBulkSds(c, slotRangeArrayToString(task->slot_ranges));
     addReplyBulkCString(c, "source");
     addReplyBulkCBuffer(c, task->source, CLUSTER_NAMELEN);
     addReplyBulkCString(c, "dest");
     addReplyBulkCBuffer(c, task->dest, CLUSTER_NAMELEN);
     addReplyBulkCString(c, "operation");
-    addReplyBulkCString(c, task->operation == ASM_IMPORT ? "importing" : "migrating");
+    addReplyBulkCString(c, task->operation == ASM_IMPORT ? "import" : "migrate");
     addReplyBulkCString(c, "state");
     addReplyBulkCString(c, asmTaskStateToString(task->state));
     addReplyBulkCString(c, "last_error");
@@ -1973,13 +1973,12 @@ void clusterSyncSlotsCommand(client *c) {
 
             /* Pause write if needed */
             if (task->state == ASM_SEND_BULK_AND_STREAM || task->state == ASM_SEND_STREAM) {
-                /* Pause writes on the main channel connection if the gap is
-                 * less than the desired threshold. */
-                if (task->dest_offset + server.asm_pause_write_max_gap_size >= task->source_offset) {
-                    serverLog(LL_NOTICE, "The applied offset gap %lld is less than the threshold %lld, "
+                /* Pause writes on the main channel if the lag is less than the threshold. */
+                if (task->dest_offset + server.asm_handoff_max_lag_size >= task->source_offset) {
+                    serverLog(LL_NOTICE, "The applied offset lag %lld is less than the threshold %lld, "
                                          "pausing writes for slot handoff",
                                          task->source_offset - task->dest_offset,
-                                         server.asm_pause_write_max_gap_size);
+                                         server.asm_handoff_max_lag_size);
                     task->state = ASM_HANDOFF_PREP;
                     clusterAsmOnEvent(task->id, ASM_EVENT_HANDOFF_PREP, task->slot_ranges);
                 }
@@ -2457,7 +2456,7 @@ void asmBeforeSleep(void) {
 
         if (task->state == ASM_HANDOFF) {
             /* To avoid long pause, we fail the task if the pause takes too long. */
-            if (server.mstime - task->paused_time >= server.asm_pause_write_timeout) {
+            if (server.mstime - task->paused_time >= server.asm_write_pause_timeout) {
                 asmTaskSetFailed(task, "Server paused timeout");
                 return;
             }
@@ -2474,7 +2473,7 @@ void asmBeforeSleep(void) {
              * However, the configuration will eventually converge. In most cases,
              * the destination node becomes the winner, since it bumps its config
              * epoch before taking over slot ownership. */
-            if (server.mstime - task->paused_time >= server.asm_pause_write_timeout)
+            if (server.mstime - task->paused_time >= server.asm_write_pause_timeout)
                 asmTaskSetFailed(task, "Server paused timeout");
         }
     }

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -6131,7 +6131,7 @@ int clusterCommandSpecial(client *c) {
             addReplyErrorFormat(c, "There is a pending trim job for slot %d. "
                 "Most probably, this is due to a failed atomic slot migration. "
                 "CLUSTER SETSLOT cannot be used at this time. "
-                "Please retry later once the trim job is done. ", slot);
+                "Please retry later once the trim job is completed.", slot);
             return 1;
         }
 

--- a/src/commands/cluster-migration.json
+++ b/src/commands/cluster-migration.json
@@ -126,7 +126,7 @@
                             "start_time": {
                                 "type": "integer"
                             },
-                            "done_time": {
+                            "end_time": {
                                 "type": "integer"
                             },
                             "write_pause_ms": {

--- a/src/config.c
+++ b/src/config.c
@@ -3217,7 +3217,7 @@ standardConfig static_configs[] = {
     createIntConfig("shutdown-timeout", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.shutdown_timeout, 10, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("repl-diskless-sync-max-replicas", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.repl_diskless_sync_max_replicas, 0, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("cluster-compatibility-sample-ratio", NULL, MODIFIABLE_CONFIG, 0, 100, server.cluster_compatibility_sample_ratio, 0, INTEGER_CONFIG, NULL, NULL),
-    createIntConfig("slot-migration-max-done-tasks", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, 1, INT_MAX, server.asm_max_done_tasks, 32, INTEGER_CONFIG, NULL, NULL),
+    createIntConfig("slot-migration-max-archived-tasks", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, 1, INT_MAX, server.asm_max_archived_tasks, 32, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("slot-migration-trim-slow-cycle-time-perc", NULL, MODIFIABLE_CONFIG, 0, 100, server.asm_trim_slow_cycle_time_perc, 25, INTEGER_CONFIG, NULL, NULL), /* CPU max % for keys collection */
     createIntConfig("slot-migration-trim-fast-cycle-duration", NULL, MODIFIABLE_CONFIG, 0, 1000000, server.asm_trim_fast_cycle_duration, 0, INTEGER_CONFIG, NULL, NULL), /* Microseconds */
 

--- a/src/config.c
+++ b/src/config.c
@@ -3240,8 +3240,8 @@ standardConfig static_configs[] = {
     createLongLongConfig("busy-reply-threshold", "lua-time-limit", MODIFIABLE_CONFIG, 0, LONG_MAX, server.busy_reply_threshold, 5000, INTEGER_CONFIG, NULL, NULL),/* milliseconds */
     createLongLongConfig("cluster-node-timeout", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.cluster_node_timeout, 15000, INTEGER_CONFIG, NULL, NULL),
     createLongLongConfig("cluster-ping-interval", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, 0, LLONG_MAX, server.cluster_ping_interval, 0, INTEGER_CONFIG, NULL, NULL),
-    createLongLongConfig("slot-migration-pause-write-max-gap-size", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.asm_pause_write_max_gap_size, 1*1024*1024, MEMORY_CONFIG, NULL, NULL), /* 1MB */
-    createLongLongConfig("slot-migration-pause-write-timeout", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.asm_pause_write_timeout, 10*1000, INTEGER_CONFIG, NULL, NULL), /* 10 seconds */
+    createLongLongConfig("slot-migration-handoff-max-lag-size", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.asm_handoff_max_lag_size, 1*1024*1024, MEMORY_CONFIG, NULL, NULL), /* 1MB */
+    createLongLongConfig("slot-migration-write-pause-timeout", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.asm_write_pause_timeout, 10*1000, INTEGER_CONFIG, NULL, NULL), /* 10 seconds */
     createLongLongConfig("slot-migration-sync-buffer-drain-timeout", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, 0, LLONG_MAX, server.asm_sync_buffer_drain_timeout, 60000, INTEGER_CONFIG, NULL, NULL), /* 60 seconds */
     createLongLongConfig("slowlog-log-slower-than", NULL, MODIFIABLE_CONFIG, -1, LLONG_MAX, server.slowlog_log_slower_than, 10000, INTEGER_CONFIG, NULL, NULL),
     createLongLongConfig("latency-monitor-threshold", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.latency_monitor_threshold, 0, INTEGER_CONFIG, NULL, NULL),

--- a/src/config.c
+++ b/src/config.c
@@ -3240,7 +3240,7 @@ standardConfig static_configs[] = {
     createLongLongConfig("busy-reply-threshold", "lua-time-limit", MODIFIABLE_CONFIG, 0, LONG_MAX, server.busy_reply_threshold, 5000, INTEGER_CONFIG, NULL, NULL),/* milliseconds */
     createLongLongConfig("cluster-node-timeout", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.cluster_node_timeout, 15000, INTEGER_CONFIG, NULL, NULL),
     createLongLongConfig("cluster-ping-interval", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, 0, LLONG_MAX, server.cluster_ping_interval, 0, INTEGER_CONFIG, NULL, NULL),
-    createLongLongConfig("slot-migration-handoff-max-lag-size", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.asm_handoff_max_lag_size, 1*1024*1024, MEMORY_CONFIG, NULL, NULL), /* 1MB */
+    createLongLongConfig("slot-migration-handoff-max-lag-bytes", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.asm_handoff_max_lag_bytes, 1*1024*1024, MEMORY_CONFIG, NULL, NULL), /* 1MB */
     createLongLongConfig("slot-migration-write-pause-timeout", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.asm_write_pause_timeout, 10*1000, INTEGER_CONFIG, NULL, NULL), /* 10 seconds */
     createLongLongConfig("slot-migration-sync-buffer-drain-timeout", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, 0, LLONG_MAX, server.asm_sync_buffer_drain_timeout, 60000, INTEGER_CONFIG, NULL, NULL), /* 60 seconds */
     createLongLongConfig("slowlog-log-slower-than", NULL, MODIFIABLE_CONFIG, -1, LLONG_MAX, server.slowlog_log_slower_than, 10000, INTEGER_CONFIG, NULL, NULL),

--- a/src/server.h
+++ b/src/server.h
@@ -2256,8 +2256,8 @@ struct redisServer {
     mstime_t cluster_node_timeout; /* Cluster node timeout. */
     mstime_t cluster_ping_interval;    /* A debug configuration for setting how often cluster nodes send ping messages. */
     char *cluster_configfile; /* Cluster auto-generated config file name. */
-    long long asm_pause_write_max_gap_size; /* Maximum gap in bytes before pausing writes before ASM handoff. */
-    long long asm_pause_write_timeout; /* Timeout in milliseconds to pause writes during ASM handoff. */
+    long long asm_handoff_max_lag_size; /* Maximum lag in bytes before pausing writes for ASM handoff. */
+    long long asm_write_pause_timeout; /* Timeout in milliseconds to pause writes during ASM handoff. */
     long long asm_sync_buffer_drain_timeout; /* Timeout in milliseconds for sync buffer to drain during ASM. */
     int asm_max_archived_tasks; /* Maximum number of archived ASM tasks to keep in memory. */
     struct clusterState *cluster;  /* State of the cluster */

--- a/src/server.h
+++ b/src/server.h
@@ -2259,7 +2259,7 @@ struct redisServer {
     long long asm_pause_write_max_gap_size; /* Maximum gap in bytes before pausing writes before ASM handoff. */
     long long asm_pause_write_timeout; /* Timeout in milliseconds to pause writes during ASM handoff. */
     long long asm_sync_buffer_drain_timeout; /* Timeout in milliseconds for sync buffer to drain during ASM. */
-    int asm_max_done_tasks; /* Maximum number of completed ASM tasks to keep in memory. */
+    int asm_max_archived_tasks; /* Maximum number of archived ASM tasks to keep in memory. */
     struct clusterState *cluster;  /* State of the cluster */
     int cluster_migration_barrier; /* Cluster replicas migration barrier. */
     int cluster_allow_replica_migration; /* Automatic replica migrations to orphaned masters and from empty masters */

--- a/src/server.h
+++ b/src/server.h
@@ -2256,7 +2256,7 @@ struct redisServer {
     mstime_t cluster_node_timeout; /* Cluster node timeout. */
     mstime_t cluster_ping_interval;    /* A debug configuration for setting how often cluster nodes send ping messages. */
     char *cluster_configfile; /* Cluster auto-generated config file name. */
-    long long asm_handoff_max_lag_size; /* Maximum lag in bytes before pausing writes for ASM handoff. */
+    long long asm_handoff_max_lag_bytes; /* Maximum lag in bytes before pausing writes for ASM handoff. */
     long long asm_write_pause_timeout; /* Timeout in milliseconds to pause writes during ASM handoff. */
     long long asm_sync_buffer_drain_timeout; /* Timeout in milliseconds for sync buffer to drain during ASM. */
     int asm_max_archived_tasks; /* Maximum number of archived ASM tasks to keep in memory. */

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -243,8 +243,8 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         assert_error {*overlapping import exists*} {R 0 CLUSTER MIGRATION IMPORT 6500 7500}
 
         wait_for_condition 1000 50 {
-            [string match {*done*} [migration_status 0 $task_id state]] &&
-            [string match {*done*} [migration_status 1 $task_id state]]
+            [string match {*completed*} [migration_status 0 $task_id state]] &&
+            [string match {*completed*} [migration_status 1 $task_id state]]
         } else {
             fail "ASM task did not start"
         }
@@ -901,8 +901,8 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         # the importing task on #0 will be retried, and eventually succeed
         # since now #0 is back in the cluster
         wait_for_condition 2000 50 {
-            [string match {*done*} [migration_status 0 $task_id state]] &&
-            [string match {*done*} [migration_status 1 $task_id state]]
+            [string match {*completed*} [migration_status 0 $task_id state]] &&
+            [string match {*completed*} [migration_status 1 $task_id state]]
         } else {
             fail "ASM task did not finish"
         }
@@ -1885,7 +1885,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         R 1 debug asm-trim-method active 0
         R 1 flushall
 
-        set prev_trim_done [CI 1 slot_migration_active_trim_done]
+        set prev_trim_done [CI 1 slot_migration_active_trim_completed]
 
         R 1 debug populate 1000 [slot_prefix 0] 100
         R 1 debug populate 1000 [slot_prefix 1] 100
@@ -1898,7 +1898,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         R 1 exec
 
         wait_for_condition 1000 10 {
-            [CI 1 slot_migration_active_trim_done] == $prev_trim_done + 3
+            [CI 1 slot_migration_active_trim_completed] == $prev_trim_done + 3
         } else {
             fail "active trim failed"
         }

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -619,7 +619,6 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
             assert_equal [R $id dbsize] 0
 
             # but we can see the number of keys is increased in INFO KEYSPACE
-            if {$::verbose} { puts [R $id info keyspace] }
             assert {[scan [regexp -inline {keys\=([\d]*)} [R $id info keyspace]] keys=%d] >= 1}
             assert {[scan [regexp -inline {expires\=([\d]*)} [R $id info keyspace]] expires=%d] >= 1}
         }
@@ -707,7 +706,6 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         # but other keys (slot5462_key and slot5463_key) should be evicted
         after 2200
         for {set j 0} {$j < 100} {incr j} { R 1 ping } ;# trigger eviction
-        if {$::verbose} { puts [R 1 info keyspace] }
         assert_equal 0 [R 1 exists $slot5462_key]
         assert_equal 0 [R 1 exists $slot5463_key]
         assert {[scan [regexp -inline {keys\=([\d]*)} [R 1 info keyspace]] keys=%d] >= 2}
@@ -781,7 +779,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
             # start slot migration from 1 to 0
             set task_id [setup_slot_migration_with_delay 1 0 0 100]
 
-            if {$::verbose} { puts "flush command: $flushcmd"}
+            if {$::verbose} { puts "Testing flush command: $flushcmd"}
             if {$flushcmd == "flushall"} {
                 R 0 flushall
             } elseif {$flushcmd == "flushdb"} {
@@ -1126,7 +1124,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
 
     test "Source server paused timeout" {
         # set timeout to 0, so the task will fail immediately when checking timeout
-        R 0 config set slot-migration-pause-write-timeout 0
+        R 0 config set slot-migration-write-pause-timeout 0
 
         # start migration from node 0 to 1
         set task_id [setup_slot_migration_with_delay 0 1 0 100]
@@ -1147,7 +1145,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         stop_write_load $load_handle
 
         # reset config
-        R 0 config set slot-migration-pause-write-timeout 10000
+        R 0 config set slot-migration-write-pause-timeout 10000
         R 0 cluster migration cancel id $task_id
         R 1 cluster migration cancel id $task_id
     }
@@ -1155,7 +1153,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
     test "Sync buffer drain timeout" {
         # set a very small gap size, so the gap between source and destination will
         # not be less than the threshold if we continue writing the source.
-        R 0 config set slot-migration-pause-write-max-gap-size 0
+        R 0 config set slot-migration-handoff-max-lag-bytes 0
         R 0 config set slot-migration-sync-buffer-drain-timeout 5000
 
         set r1_pid [S 1 process_id]
@@ -1189,7 +1187,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-node-timeout 
         resume_process $r1_pid
 
         # reset config
-        R 0 config set slot-migration-pause-write-max-gap-size 1mb
+        R 0 config set slot-migration-handoff-max-lag-bytes 1mb
         R 0 config set slot-migration-sync-buffer-drain-timeout 60000
         R 0 cluster migration cancel id $task_id
         R 1 cluster migration cancel id $task_id


### PR DESCRIPTION
- `done_time` -> `end_time`
- `done_tasks` -> `archived_tasks`
- `active_trim_done` -> `active_trim_completed`
- `ASM_DONE` -> `ASM_COMPLETED`
- `ASM_STREAM_DONE` -> `ASM_STREAM_EOF` align with `WAIT_STREAM_EOF` and `SNAPSHOT_EOF`
- `slot_migration_total_done_tasks` in cluster info is not clear, remove it
- `slot-migration-pause-write-max-gap-size` to `slot-migration-handoff-max-lag-bytes`
- `slot-migration-pause-write-timeout` to `slot-migration-write-pause-timeout`