### PR TITLE
Add ASM_EVENT_IMPORT_PREP and ASM_EVENT_MIGRATE_PREP

### DIFF
--- a/src/cluster.h
+++ b/src/cluster.h
@@ -279,12 +279,14 @@ int clusterNodeTlsPort(clusterNode *node);
 #define ASM_EVENT_TAKEOVER          5  /* Ready to take over the slot, waiting for config change (destination side) */
 #define ASM_EVENT_DONE              6  /* Notify that import/migrate is completed, config is updated (source and destination side) */
 
-#define ASM_EVENT_IMPORT_STARTED    7  /* Import started */
-#define ASM_EVENT_IMPORT_FAILED     8  /* Import failed */
-#define ASM_EVENT_IMPORT_COMPLETED  9  /* Import completed (config updated) */
-#define ASM_EVENT_MIGRATE_STARTED   10 /* Migration started */
-#define ASM_EVENT_MIGRATE_FAILED    11 /* Migration failed */
-#define ASM_EVENT_MIGRATE_COMPLETED 12 /* Migrate completed (config updated) */
+#define ASM_EVENT_IMPORT_PREP       7  /* Import is about to start, the implementation may reject by returning C_ERR */
+#define ASM_EVENT_IMPORT_STARTED    8  /* Import started */
+#define ASM_EVENT_IMPORT_FAILED     9  /* Import failed */
+#define ASM_EVENT_IMPORT_COMPLETED  10 /* Import completed (config updated) */
+#define ASM_EVENT_MIGRATE_PREP      11 /* Migrate is about to start, the implementation may reject by returning C_ERR */
+#define ASM_EVENT_MIGRATE_STARTED   12 /* Migrate started */
+#define ASM_EVENT_MIGRATE_FAILED    13 /* Migrate failed */
+#define ASM_EVENT_MIGRATE_COMPLETED 14 /* Migrate completed (config updated) */
 
 
 /* Called by cluster implementation to request an ASM operation. (cluster impl --> redis)
@@ -334,7 +336,9 @@ int clusterAsmProcess(const char *task_id, int event, void *arg, char **err);
 /* Called when an ASM event occurs to notify the cluster implementation. (redis --> cluster impl)
  *
  * `arg` will point to a `slotRangeArray` for the following events:
+ *  ASM_EVENT_IMPORT_PREP
  *  ASM_EVENT_IMPORT_STARTED
+ *  ASM_EVENT_MIGRATE_PREP
  *  ASM_EVENT_MIGRATE_STARTED
  *  ASM_EVENT_HANDOFF_PREP
  *
@@ -342,6 +346,9 @@ int clusterAsmProcess(const char *task_id, int event, void *arg, char **err);
  *  - Redis owns the `task_id` and `slotRangeArray`.
  *
  *  Returns C_OK on success.
+ *
+ *  If the cluster implementation returns C_ERR for ASM_EVENT_IMPORT_PREP or
+ *  ASM_EVENT_MIGRATE_PREP, operation will not start.
  **/
 int clusterAsmOnEvent(const char *task_id, int event, void *arg);
 

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -1691,14 +1691,19 @@ static void asmStartImportTask(asmTask *task) {
      * We can't start the import task since the trim job will modify the data.*/
     int trim_in_progress = asmIsAnyTrimJobOverlaps(task->slots);
 
+    /* Notify the cluster implementation to prepare for the import task. */
+    int impl_ret = clusterAsmOnEvent(task->id, ASM_EVENT_IMPORT_PREP, task->slots);
+
     static int start_blocked_logged = 0;
     /* Cannot start import task since pause action is performed. Otherwise, we
      * will break the promise that no writes are performed during the pause. */
     if (isPausedActions(PAUSE_ACTION_CLIENT_ALL) ||
         isPausedActions(PAUSE_ACTION_CLIENT_WRITE) ||
-        trim_in_progress)
+        trim_in_progress ||
+        impl_ret != C_OK)
     {
-        const char *reason = trim_in_progress ? "trim in progress for some of the slots" :
+        const char *reason = impl_ret != C_OK ? "cluster is not ready" :
+                             trim_in_progress ? "trim in progress for some of the slots" :
                                                 "server paused";
         if (start_blocked_logged == 0) {
             serverLog(LL_WARNING, "Can not start import task %s for slots: %s due to %s",
@@ -1807,6 +1812,13 @@ void clusterSyncSlotsCommand(client *c) {
         }
 
         sds task_id = c->argv[3]->ptr;
+        /* Notify the cluster implementation to prepare for the migrate task. */
+        if (clusterAsmOnEvent(task_id, ASM_EVENT_MIGRATE_PREP, slots) != C_OK) {
+            addReplyError(c, "Cluster is not ready right now, please retry later");
+            slotRangeArrayFree(slots);
+            return;
+        }
+
         asmTask *task = listLength(asmManager->tasks) == 0 ? NULL :
                             listNodeValue(listFirst(asmManager->tasks));
         if (task && !strcmp(task->id, task_id) &&

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -6569,9 +6569,10 @@ void clusterPromoteSelfToMaster(void) {
 
 int clusterAsmOnEvent(const char *task_id, int event, void *arg) {
     UNUSED(arg);
+    sds str = NULL;
 
     slotRangeArray *slots = asmTaskGetSlotRanges(task_id);
-    sds str = slotRangeArrayToString(slots);
+    if (slots) str = slotRangeArrayToString(slots);
 
     switch (event) {
         case ASM_EVENT_IMPORT_STARTED:


### PR DESCRIPTION
Added `ASM_EVENT_IMPORT_PREP` and `ASM_EVENT_MIGRATE_PREP`. 
The idea is that implementation may reject starting a new operation if some resources are not yet available on its side. 