### PR TITLE
Allow modules to delay trimming

### DIFF
--- a/src/cluster.h
+++ b/src/cluster.h
@@ -53,6 +53,7 @@ typedef struct clusterSlotStat {
 #define CLUSTER_MODULE_FLAG_NONE 0
 #define CLUSTER_MODULE_FLAG_NO_FAILOVER (1<<1)
 #define CLUSTER_MODULE_FLAG_NO_REDIRECTION (1<<2)
+#define CLUSTER_MODULE_FLAG_NO_TRIM (1<<3)
 
 /* ---------------------- API exported outside cluster.c -------------------- */
 

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -2939,15 +2939,22 @@ void asmTrimJobProcessPending(void) {
 
     /* Determine if we can start the trim job:
      * - require client writes not paused (so key deletions are allowed)
-     * - require replicas not paused (so TRIMSLOTS can be propagated). */
+     * - require replicas not paused (so TRIMSLOTS can be propagated).
+     * - require trim is not disabled via RM_SetClusterFlags().
+     */
     static int logged = 0;
+    int disabled_by_module = server.cluster_module_flags & REDISMODULE_CLUSTER_FLAG_NO_TRIM;
+
     if (isPausedActions(PAUSE_ACTION_CLIENT_WRITE) ||
         isPausedActions(PAUSE_ACTION_CLIENT_ALL) ||
-        isPausedActions(PAUSE_ACTION_REPLICA))
+        isPausedActions(PAUSE_ACTION_REPLICA) ||
+        disabled_by_module)
     {
         if (logged == 0) {
             logged = 1;
-            serverLog(LL_NOTICE, "Trim job will start after the write pause is lifted.");
+            const char *reason = disabled_by_module ? "trim is disabled by module" :
+                                                      "pause action is in effect";
+            serverLog(LL_NOTICE, "Trim job is deferred since %s.", reason);
         }
         return;
     }
@@ -3325,18 +3332,23 @@ void asmActiveTrimCycle(void) {
         return;
     }
 
-    /* Verify client pause is not in effect so we can delete keys. */
+    /* Verify client pause is not in effect and trim is not disabled by module,
+     * so we can delete keys. */
     static int blocked = 0;
+    int disabled_by_module = server.cluster_module_flags & REDISMODULE_CLUSTER_FLAG_NO_TRIM;
     if (isPausedActions(PAUSE_ACTION_CLIENT_ALL) ||
-        isPausedActions(PAUSE_ACTION_CLIENT_WRITE))
+        isPausedActions(PAUSE_ACTION_CLIENT_WRITE) ||
+        disabled_by_module)
     {
         if (blocked == 0)  {
             blocked = 1;
-            serverLog(LL_NOTICE, "Active trim cycle will continue after the write pause is lifted.");
+            const char *reason = disabled_by_module ? "trim is disabled by module" :
+                                                       "pause action is in effect";
+            serverLog(LL_NOTICE, "Active trim cycle is blocked since %s.", reason);
         }
         return;
     }
-    if (blocked) serverLog(LL_NOTICE, "Active trim cycle is resumed after the write pause is lifted.");
+    if (blocked) serverLog(LL_NOTICE, "Active trim cycle is unblocked.");
     blocked = 0;
 
     /* This works in a similar way to activeExpireCycle, in the sense that
@@ -3393,28 +3405,10 @@ void asmActiveTrimCycle(void) {
     }
 }
 
-/* Trim a specific key if trimming is pending or in progress for its slot.
- * Return 1 if the key was trimmed */
-int asmActiveTrimDelIfNeeded(redisDb *db, robj *key, kvobj *kv) {
-    /* Check if trimming is in progress. */
-    if (server.allow_access_trimmed ||
-        !asmIsTrimInProgress())
-    {
+/* Check if the key in a trim job. */
+int asmIsKeyInTrimJob(sds keyname) {
+    if (!asmIsTrimInProgress() || !isSlotInTrimJob(getKeySlot(keyname)))
         return 0;
-    }
-
-    /* Check if the slot is in a trim job. */
-    sds keyname = key ? key->ptr : kvobjGetKey(kv);
-    if (!isSlotInTrimJob(getKeySlot(keyname)))
-        return 0;
-
-    if (key) {
-        asmActiveTrimDeleteKey(db, key);
-    } else {
-        robj *tmpkey = createStringObject(keyname, sdslen(keyname));
-        asmActiveTrimDeleteKey(db, tmpkey);
-        decrRefCount(tmpkey);
-    }
     return 1;
 }
 

--- a/src/cluster_asm.h
+++ b/src/cluster_asm.h
@@ -51,7 +51,7 @@ void asmFinalizeMasterTask(void);
 int asmIsTrimInProgress(void);
 int asmGetTrimmingSlotForCommand(struct redisCommand *cmd, robj **argv, int argc);
 void asmActiveTrimCycle(void);
-int asmActiveTrimDelIfNeeded(redisDb *db, robj *key, kvobj *kv);
+int asmIsKeyInTrimJob(sds keyname);
 int asmModulePropagateBeforeSlotSnapshot(struct redisCommand *cmd, robj **argv, int argc);
 #endif
 

--- a/src/db.c
+++ b/src/db.c
@@ -35,12 +35,14 @@ static_assert(MAX_KEYSIZES_TYPES == OBJ_TYPE_BASIC_MAX, "Must be equal");
 #define EXPIRE_FORCE_DELETE_EXPIRED 1
 #define EXPIRE_AVOID_DELETE_EXPIRED 2
 #define EXPIRE_ALLOW_ACCESS_EXPIRED 4
+#define EXPIRE_ALLOW_ACCESS_TRIMMED 8
 
 /* Return values for expireIfNeeded */
 typedef enum {
     KEY_VALID = 0, /* Could be volatile and not yet expired, non-volatile, or even non-existing key. */
     KEY_EXPIRED, /* Logically expired but not yet deleted. */
-    KEY_DELETED /* The key was deleted now. */
+    KEY_DELETED, /* The key was deleted now. */
+    KEY_TRIMMED /* Logically trimmed but not yet deleted. */
 } keyStatus;
 
 static keyStatus expireIfNeeded(redisDb *db, robj *key, kvobj *kv, int flags);
@@ -255,6 +257,8 @@ kvobj *lookupKey(redisDb *db, robj *key, int flags, dictEntryLink *link) {
             expire_flags |= EXPIRE_AVOID_DELETE_EXPIRED;
         if (flags & LOOKUP_ACCESS_EXPIRED)
             expire_flags |= EXPIRE_ALLOW_ACCESS_EXPIRED;
+        if (flags & LOOKUP_ACCESS_TRIMMED)
+            expire_flags |= EXPIRE_ALLOW_ACCESS_TRIMMED;
         if (expireIfNeeded(db, key, val, expire_flags) != KEY_VALID) {
             /* The key is no longer valid. */
             val = NULL;
@@ -2729,7 +2733,8 @@ int confAllowsExpireDel(void) {
  *
  * The return value of the function is KEY_VALID if the key is still valid.
  * The function returns KEY_EXPIRED if the key is expired BUT not deleted,
- * or returns KEY_DELETED if the key is expired and deleted.
+ * or returns KEY_DELETED if the key is expired and deleted. If the key is in a
+ * trim job due to slot migration, the function returns KEY_TRIMMED.
  *
  * You can optionally pass `kv` to save a lookup.
  */
@@ -2739,7 +2744,14 @@ keyStatus expireIfNeeded(redisDb *db, robj *key, kvobj *kv, int flags) {
     /* NOTE: Keys in slots scheduled for trimming can still exist for a while.
      * If a module touches one of these keys, we remove it right away and
      * return KEY_DELETED. */
-    if (asmActiveTrimDelIfNeeded(db, key, kv)) return KEY_DELETED;
+    sds key_name = key ? key->ptr : kvobjGetKey(kv);
+    if (asmIsKeyInTrimJob(key_name)) {
+        if (server.allow_access_trimmed || (flags & EXPIRE_ALLOW_ACCESS_TRIMMED))
+            return KEY_VALID;
+
+        /* Key is in a trim job */
+        return KEY_TRIMMED;
+    }
 
     if ((flags & EXPIRE_ALLOW_ACCESS_EXPIRED) ||
         (!keyIsExpired(db,  key ? key->ptr : NULL, kv)))

--- a/src/module.c
+++ b/src/module.c
@@ -9379,6 +9379,7 @@ int RM_GetClusterNodeInfo(RedisModuleCtx *ctx, const char *id, char *ip, char *m
  *
  * * CLUSTER_MODULE_FLAG_NO_FAILOVER
  * * CLUSTER_MODULE_FLAG_NO_REDIRECTION
+ * * CLUSTER_MODULE_FLAG_NO_TRIM
  *
  * With the following effects:
  *

--- a/src/module.c
+++ b/src/module.c
@@ -3940,6 +3940,8 @@ int RM_GetSelectedDb(RedisModuleCtx *ctx) {
  *
  *  * REDISMODULE_CTX_FLAGS_DEBUG_ENABLED: Debug commands are enabled for this
  *                                         context.
+ *  * REDISMODULE_CTX_FLAGS_TRIM_IN_PROGRESS: Trim is in progress due to slot
+ *                                            migration.
  */
 int RM_GetContextFlags(RedisModuleCtx *ctx) {
     int flags = 0;
@@ -4036,6 +4038,9 @@ int RM_GetContextFlags(RedisModuleCtx *ctx) {
     if (server.enable_debug_cmd == PROTECTED_ACTION_ALLOWED_YES) {
         flags |= REDISMODULE_CTX_FLAGS_DEBUG_ENABLED;
     }
+
+    if (asmIsTrimInProgress())
+        flags |= REDISMODULE_CTX_TRIM_IN_PROGRESS;
 
     return flags;
 }
@@ -4142,6 +4147,7 @@ RedisModuleKey *RM_OpenKey(RedisModuleCtx *ctx, robj *keyname, int mode) {
     flags |= (mode & REDISMODULE_OPEN_KEY_NOEXPIRE? LOOKUP_NOEXPIRE: 0);
     flags |= (mode & REDISMODULE_OPEN_KEY_NOEFFECTS? LOOKUP_NOEFFECTS: 0);
     flags |= (mode & REDISMODULE_OPEN_KEY_ACCESS_EXPIRED ? (LOOKUP_ACCESS_EXPIRED) : 0);
+    flags |= (mode & REDISMODULE_OPEN_KEY_ACCESS_TRIMMED ? (LOOKUP_ACCESS_TRIMMED) : 0);
 
     if (mode & REDISMODULE_WRITE) {
         kv = lookupKeyWriteWithFlags(ctx->client->db,keyname, flags);
@@ -9382,13 +9388,30 @@ int RM_GetClusterNodeInfo(RedisModuleCtx *ctx, const char *id, char *ip, char *m
  * * NO_REDIRECTION: Every node will accept any key, without trying to perform
  *                   partitioning according to the Redis Cluster algorithm.
  *                   Slots information will still be propagated across the
- *                   cluster, but without effect. */
+ *                   cluster, but without effect.
+ *
+ * * NO_TRIM: Prevent Redis Cluster from trimming keys after atomic slot migration.
+ */
 void RM_SetClusterFlags(RedisModuleCtx *ctx, uint64_t flags) {
     UNUSED(ctx);
     if (flags & REDISMODULE_CLUSTER_FLAG_NO_FAILOVER)
         server.cluster_module_flags |= CLUSTER_MODULE_FLAG_NO_FAILOVER;
     if (flags & REDISMODULE_CLUSTER_FLAG_NO_REDIRECTION)
         server.cluster_module_flags |= CLUSTER_MODULE_FLAG_NO_REDIRECTION;
+    if (flags & REDISMODULE_CLUSTER_FLAG_NO_TRIM)
+        server.cluster_module_flags |= CLUSTER_MODULE_FLAG_NO_TRIM;
+}
+
+/* Return the current cluster flags set by the module. */
+uint64_t RM_GetClusterFlags(void) {
+    uint64_t flags = 0;
+    if (server.cluster_module_flags & CLUSTER_MODULE_FLAG_NO_FAILOVER)
+        flags |= REDISMODULE_CLUSTER_FLAG_NO_FAILOVER;
+    if (server.cluster_module_flags & CLUSTER_MODULE_FLAG_NO_REDIRECTION)
+        flags |= REDISMODULE_CLUSTER_FLAG_NO_REDIRECTION;
+    if (server.cluster_module_flags & CLUSTER_MODULE_FLAG_NO_TRIM)
+        flags |= REDISMODULE_CLUSTER_FLAG_NO_TRIM;
+    return flags;
 }
 
 /* Returns the cluster slot of a key, similar to the `CLUSTER KEYSLOT` command.
@@ -15083,6 +15106,7 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(SetDisconnectCallback);
     REGISTER_API(GetBlockedClientHandle);
     REGISTER_API(SetClusterFlags);
+    REGISTER_API(GetClusterFlags);
     REGISTER_API(ClusterKeySlot);
     REGISTER_API(ClusterKeySlotC);
     REGISTER_API(ClusterCanonicalKeyNameInSlot);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -62,11 +62,14 @@ typedef long long ustime_t;
 #define REDISMODULE_OPEN_KEY_NOEFFECTS (1<<20)
 /* Allow access expired key that haven't deleted yet */
 #define REDISMODULE_OPEN_KEY_ACCESS_EXPIRED (1<<21)
+/* Allow access trimmed key that haven't deleted yet */
+#define REDISMODULE_OPEN_KEY_ACCESS_TRIMMED (1<<22)
+
 
 /* Mask of all REDISMODULE_OPEN_KEY_* values. Any new mode should be added to this list.
  * Should not be used directly by the module, use RM_GetOpenKeyModesAll instead.
  * Located here so when we will add new modes we will not forget to update it. */
-#define _REDISMODULE_OPEN_KEY_ALL REDISMODULE_READ | REDISMODULE_WRITE | REDISMODULE_OPEN_KEY_NOTOUCH | REDISMODULE_OPEN_KEY_NONOTIFY | REDISMODULE_OPEN_KEY_NOSTATS | REDISMODULE_OPEN_KEY_NOEXPIRE | REDISMODULE_OPEN_KEY_NOEFFECTS | REDISMODULE_OPEN_KEY_ACCESS_EXPIRED
+#define _REDISMODULE_OPEN_KEY_ALL REDISMODULE_READ | REDISMODULE_WRITE | REDISMODULE_OPEN_KEY_NOTOUCH | REDISMODULE_OPEN_KEY_NONOTIFY | REDISMODULE_OPEN_KEY_NOSTATS | REDISMODULE_OPEN_KEY_NOEXPIRE | REDISMODULE_OPEN_KEY_NOEFFECTS | REDISMODULE_OPEN_KEY_ACCESS_EXPIRED | REDISMODULE_OPEN_KEY_ACCESS_TRIMMED
 
 /* List push and pop */
 #define REDISMODULE_LIST_HEAD 0
@@ -210,11 +213,13 @@ typedef struct RedisModuleStreamID {
 #define REDISMODULE_CTX_FLAGS_SERVER_STARTUP (1<<24)
 /* This context can call execute debug commands. */
 #define REDISMODULE_CTX_FLAGS_DEBUG_ENABLED (1<<25)
+/* Trim is in progress due to slot migration. */
+#define REDISMODULE_CTX_TRIM_IN_PROGRESS (1<<26)
 
 /* Next context flag, must be updated when adding new flags above!
 This flag should not be used directly by the module.
  * Use RedisModule_GetContextFlagsAll instead. */
-#define _REDISMODULE_CTX_FLAGS_NEXT (1<<26)
+#define _REDISMODULE_CTX_FLAGS_NEXT (1<<27)
 
 /* Keyspace changes notification classes. Every class is associated with a
  * character for configuration purposes.
@@ -267,6 +272,7 @@ This flag should not be used directly by the module.
 #define REDISMODULE_CLUSTER_FLAG_NONE 0
 #define REDISMODULE_CLUSTER_FLAG_NO_FAILOVER (1<<1)
 #define REDISMODULE_CLUSTER_FLAG_NO_REDIRECTION (1<<2)
+#define REDISMODULE_CLUSTER_FLAG_NO_TRIM (1<<3)
 
 #define REDISMODULE_NOT_USED(V) ((void) V)
 
@@ -1334,6 +1340,7 @@ REDISMODULE_API void (*RedisModule_GetRandomBytes)(unsigned char *dst, size_t le
 REDISMODULE_API void (*RedisModule_GetRandomHexChars)(char *dst, size_t len) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_SetDisconnectCallback)(RedisModuleBlockedClient *bc, RedisModuleDisconnectFunc callback) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_SetClusterFlags)(RedisModuleCtx *ctx, uint64_t flags) REDISMODULE_ATTR;
+REDISMODULE_API uint64_t (*RedisModule_GetClusterFlags)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API unsigned int (*RedisModule_ClusterKeySlot)(RedisModuleString *key) REDISMODULE_ATTR;
 REDISMODULE_API unsigned int (*RedisModule_ClusterKeySlotC)(const char *keystr, size_t keylen) REDISMODULE_ATTR;
 REDISMODULE_API const char *(*RedisModule_ClusterCanonicalKeyNameInSlot)(unsigned int slot) REDISMODULE_ATTR;

--- a/src/server.h
+++ b/src/server.h
@@ -3808,6 +3808,7 @@ int objectSetLRUOrLFU(robj *val, long long lfu_freq, long long lru_idle,
 #define LOOKUP_WRITE (1<<3)          /* Delete expired keys even in replicas. */
 #define LOOKUP_NOEXPIRE (1<<4)       /* Avoid deleting lazy expired keys. */
 #define LOOKUP_ACCESS_EXPIRED (1<<5) /* Allow lookup to expired key. */
+#define LOOKUP_ACCESS_TRIMMED (1<<6) /* Allow lookup to key in slots being trimmed. */
 #define LOOKUP_NOEFFECTS (LOOKUP_NONOTIFY | LOOKUP_NOSTATS | LOOKUP_NOTOUCH | LOOKUP_NOEXPIRE) /* Avoid any effects from fetching the key */
 
 static inline kvobj *dictGetKV(const dictEntry *de) {return (kvobj *) dictGetKey(de);}

--- a/tests/unit/cluster/atomic-slot-migration.tcl
+++ b/tests/unit/cluster/atomic-slot-migration.tcl
@@ -2789,10 +2789,8 @@ start_cluster 3 6 [list tags {external:skip cluster modules} config_lines [list 
             fail "migrate failed"
         }
 
-        # Try to read the key from the slot being trimmed. It will lazily trim the key.
-        set num_trimmed [CI 0 cluster_slot_migration_active_trim_current_job_trimmed]
+        # We cannot open the key since it is in a slot being trimmed
         assert_equal {} [R 0 asm.get $key]
-        assert_equal [expr $num_trimmed + 1] [CI 0 cluster_slot_migration_active_trim_current_job_trimmed]
 
         # cleanup
         R 0 debug asm-trim-method default


### PR DESCRIPTION
See the details: https://redislabs.atlassian.net/wiki/spaces/DX/pages/5507711225/Topology-Aware+Queries

This PR introduces a mechanism that allows a module to temporarily disable trimming so it can safely finish ongoing asynchronous jobs that depend on keys in migrating (and about to be trimmed) slots.

1.  Cluster Flag Control

    Looks like we already have `RM_SetClusterFlags()` for advanced use cases.This PR adds a new flag:
    `REDISMODULE_CLUSTER_FLAG_NO_TRIM`

    A module can set and later clear this flag to prevent key trimming during its operations.

    To enable this safely, `RM_GetClusterFlags()` is added so that the module can retrieve the current flags, modify them, and set them back without overwriting unrelated bits.

    Example usage:

    ```c
    void disableTrim(void) {
        uint64_t flags = RedisModule_GetClusterFlags();
        flags |= REDISMODULE_CLUSTER_FLAG_NO_TRIM;   // Set flag
        RedisModule_SetClusterFlags(NULL, flags);
    }

    void enableTrim(void) {
        uint64_t flags = RedisModule_GetClusterFlags();
        flags &= ~REDISMODULE_CLUSTER_FLAG_NO_TRIM;  // Clear flag
        RedisModule_SetClusterFlags(NULL, flags);
    }

    ```
    
2. Added `REDISMODULE_OPEN_KEY_ACCESS_TRIMMED` to `RM_OpenKey()` so that module can operate with these keys in the unowned slots. 

3. The only valid and meaningful time for a module to disable trimming appears to be after the `MIGRATE_COMPLETED` event.
    At this point:
     - The module may already be processing queries using keys that are about to be trimmed.
     - Disabling trim ensures those in-flight operations complete safely.

    Q: What if another migration completes while trimming is still paused?
    The module must be able to handle this complexity, possibly by maintaining an internal counter or reference count of ongoing operations.

4. Optionally, we could extend `RM_GetContextFlags()` to include a flag indicating whether a trimming job is pending.
Modules could periodically poll this flag to synchronize their internal state, e.g., if a trim job was delayed or if the module incorrectly assumed trimming was still active.


